### PR TITLE
if an image has buildArgs, make its tag depend on chartpress.yaml

### DIFF
--- a/chartpress.py
+++ b/chartpress.py
@@ -132,6 +132,10 @@ def build_images(prefix, images, tag=None, commit_range=None, push=False):
         image_path = options.get('contextPath', os.path.join('images', name))
         image_tag = tag
         paths = options.get('paths', []) + [image_path]
+        if options.get('buildArgs'):
+            # if an image has build args in chartpress.yaml,
+            # the image is sensitive to changes in chartpress.yaml itself
+            paths.append('chartpress.yaml')
         last_commit = last_modified_commit(*paths)
         if tag is None:
             image_tag = last_commit


### PR DESCRIPTION
so that changes to buildArgs will be reflected in a new image tag

See https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/696