### PR TITLE
Added option to change docker image prefix

### DIFF
--- a/chartpress.py
+++ b/chartpress.py
@@ -266,7 +266,7 @@ def main():
         help='Use this tag for images & charts')
     argparser.add_argument('--extra-message', default='',
         help='extra message to add to the commit message when publishing charts')
-    argparser.add_argument('--set-prefix', default='',
+    argparser.add_argument('--set-prefix', default=None,
         help='override image prefix with this value')
 
     args = argparser.parse_args()
@@ -276,7 +276,7 @@ def main():
 
     for chart in config['charts']:
         if 'images' in chart:
-            image_prefix = args.set_prefix if args.set_prefix != '' else chart['imagePrefix']
+            image_prefix = args.set_prefix if args.set_prefix is not None else chart['imagePrefix']
             value_mods = build_images(
                 prefix=image_prefix,
                 images=chart['images'],

--- a/chartpress.py
+++ b/chartpress.py
@@ -266,7 +266,7 @@ def main():
         help='Use this tag for images & charts')
     argparser.add_argument('--extra-message', default='',
         help='extra message to add to the commit message when publishing charts')
-    argparser.add_argument('--set-prefix', default=None,
+    argparser.add_argument('--image-prefix', default=None,
         help='override image prefix with this value')
 
     args = argparser.parse_args()
@@ -276,7 +276,7 @@ def main():
 
     for chart in config['charts']:
         if 'images' in chart:
-            image_prefix = args.set_prefix if args.set_prefix is not None else chart['imagePrefix']
+            image_prefix = args.image_prefix if args.image_prefix is not None else chart['imagePrefix']
             value_mods = build_images(
                 prefix=image_prefix,
                 images=chart['images'],

--- a/chartpress.py
+++ b/chartpress.py
@@ -266,6 +266,8 @@ def main():
         help='Use this tag for images & charts')
     argparser.add_argument('--extra-message', default='',
         help='extra message to add to the commit message when publishing charts')
+    argparser.add_argument('--set-prefix', default='',
+        help='override image prefix with this value')
 
     args = argparser.parse_args()
 
@@ -274,8 +276,9 @@ def main():
 
     for chart in config['charts']:
         if 'images' in chart:
+            image_prefix = args.set_prefix if args.set_prefix != '' else chart['imagePrefix']
             value_mods = build_images(
-                prefix=chart['imagePrefix'],
+                prefix=image_prefix,
                 images=chart['images'],
                 tag=args.tag,
                 commit_range=args.commit_range,


### PR DESCRIPTION
This change adds the option to overwrite the `imagePrefix` option from `chartpress.yaml`.

This allows to fork, modify and test a project without having to edit `chartpress.yaml`, as you can then publish container images to a different Docker registry and/or repository.