### PR TITLE
ensure tag string is quoted

### DIFF
--- a/chartpress.py
+++ b/chartpress.py
@@ -12,6 +12,7 @@ import shutil
 from tempfile import TemporaryDirectory
 
 from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import SingleQuotedScalarString
 
 __version__ = '0.3.0.dev'
 
@@ -147,7 +148,7 @@ def build_images(prefix, images, tag=None, commit_range=None, push=False):
 
         value_modifications[options['valuesPath']] = {
             'repository': image_name,
-            'tag': image_tag,
+            'tag': SingleQuotedScalarString(image_tag),
         }
 
         if tag is None and commit_range and not path_touched(*paths, commit_range=commit_range):


### PR DESCRIPTION
workaround bizarre ruamel.yaml bug that results in unquoted strings that are all-digits and start with 0 and contain an 8 or 9.

closes #15