### PR TITLE
Fix build_values mapping check

### DIFF
--- a/chartpress.py
+++ b/chartpress.py
@@ -7,8 +7,9 @@ This is used as part of the JupyterHub and Binder projects.
 
 import argparse
 import os
-import subprocess
 import shutil
+import subprocess
+from collections.abc import MutableMapping
 from tempfile import TemporaryDirectory
 
 from ruamel.yaml import YAML
@@ -184,7 +185,7 @@ def build_values(name, values_mods):
             mod_obj = mod_obj[p]
         print(f"Updating {values_file}: {key}: {value}")
 
-        if isinstance(mod_obj, dict):
+        if isinstance(mod_obj, MutableMapping):
             keys = IMAGE_REPOSITORY_KEYS & mod_obj.keys()
             if keys:
                 for key in keys:


### PR DESCRIPTION
The yaml parser creates objects which do not have `dict` as a parent class, but `collections.abc.MutableMapping`.

See source for `ruamel.yaml.comments.CommentedMap`: https://bitbucket.org/ruamel/yaml/src/c177aa5d95fd92911eba4b40d60ac20b4e940105/comments.py?at=default&fileviewer=file-view-default#comments.py-595