### PR TITLE
Support more than dict mappings

### DIFF
--- a/chartpress.py
+++ b/chartpress.py
@@ -9,6 +9,7 @@ import argparse
 import os
 import subprocess
 import shutil
+from collections.abc import Mapping
 from tempfile import TemporaryDirectory
 
 from ruamel.yaml import YAML
@@ -184,7 +185,7 @@ def build_values(name, values_mods):
             mod_obj = mod_obj[p]
         print(f"Updating {values_file}: {key}: {value}")
 
-        if isinstance(mod_obj, dict):
+        if isinstance(mod_obj, Mapping):
             keys = IMAGE_REPOSITORY_KEYS & mod_obj.keys()
             if keys:
                 for key in keys:


### PR DESCRIPTION
@betatim was spot on in
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/831 to
figure out that we should support more forms of mappings than simply
dicts. ruamel.yaml seem to have introduced some new kind of mapping that
caused some trouble for z2jh.