### PR TITLE
provide a reset option to reset image tags and chart version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ charts:
   - name: binderhub
     # the prefix to use for built images
     imagePrefix: jupyterhub/k8s-
+    # tag to use when resetting the chart values
+    # with --reset command-line option (defaults to "set-by-chartpress")
+    resetTag: latest
     # the git repo whose gh-pages contains the charts
     repo:
       git: jupyterhub/helm-chart

--- a/chartpress.py
+++ b/chartpress.py
@@ -237,10 +237,6 @@ def build_images(prefix, images, tag=None, commit_range=None, push=False, chart_
         if skip_build:
             continue
 
-        if tag is None and commit_range and not path_touched(*paths, commit_range=commit_range):
-            print(f"Skipping {name}, not touched in {commit_range}")
-            continue
-
         template_namespace = {
             'LAST_COMMIT': last_commit,
             'TAG': image_tag,


### PR DESCRIPTION
Provide a `--sanitize` option to reset the image tags. This is useful to avoid committing unwanted changes to chart image tags. 