### PR TITLE
check for image existence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,8 @@ install:
 script:
   - chartpress -h
   - pyflakes .
+  - |
+    # run chartpress on zero-to-jupyterhub
+    git clone https://github.com/jupyterhub/zero-to-jupyterhub
+    cd zero-to-jupyterhub
+    chartpress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 0.3.1
 
 - Fix conditionals for builds with new tagging scheme,
-  by checking if images exist (using `docker manifest inspect`)
+  by checking if images exist locally or on the registry
   rather than assuming the correct tag was pushed based on commit range.
 - Echo shell commands that are executed during the chartpress process
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.3
 
+### 0.3.1
+
+- Fix conditionals for builds with new tagging scheme,
+  by checking if images exist (using `docker manifest inspect`)
+  rather than assuming the correct tag was pushed based on commit range.
+- Echo shell commands that are executed during the chartpress process
+
 ### 0.3.0
 
 - Add chart version as prefix to image tags (e.g. 0.8-abc123)

--- a/chartpress.py
+++ b/chartpress.py
@@ -30,9 +30,10 @@ yaml = YAML(typ='rt')
 yaml.indent(mapping=2, offset=2, sequence=4)
 
 
-def run_cmd(call, cmd, **kwargs):
+def run_cmd(call, cmd, *, echo=True, **kwargs):
     """Run a command and echo it first"""
-    print('$> ' + ' '.join(map(pipes.quote, cmd)))
+    if echo:
+        print('$> ' + ' '.join(map(pipes.quote, cmd)))
     return call(cmd, **kwargs)
 
 
@@ -321,6 +322,7 @@ def publish_pages(name, paths, git_repo, published_repo, extra_message=''):
     check_call([
         'git', 'clone', '--no-checkout',
         git_remote(git_repo), checkout_dir],
+        echo=False,
     )
     check_call(['git', 'checkout', 'gh-pages'], cwd=checkout_dir)
 

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         'ruamel.yaml>=0.15',
+        'docker>=3.2.0',
     ],
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
checks presence of images locally and on registry for need to build/push.
This provides a much more reliable check than the commit range.

Commit range is now completely ignored.

additionally, for debugging and transparency, echo shell commands that are executed.

closes #23