### PR TITLE
avoid mangling of quotes in rendered charts (#1)

### DIFF
--- a/chartpress.py
+++ b/chartpress.py
@@ -28,6 +28,7 @@ IMAGE_REPOSITORY_KEYS = {'name', 'repository'}
 
 # use safe roundtrip yaml loader
 yaml = YAML(typ='rt')
+yaml.preserve_quotes = True ## avoid mangling of quotes
 yaml.indent(mapping=2, offset=2, sequence=4)
 
 


### PR DESCRIPTION
Some yaml values might be converted to e.g. boolean - for example, an unquoted "off" can get rendered as "false". This has made our nginx-ingress break in a way that was quite difficult to debug and can be avoided with the `preserve_quotes` flag in this PR. 