### PR TITLE
Chart and image versioning, and Chart.yaml's --reset interaction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,8 @@ script:
   - |-
     git clone https://github.com/jupyterhub/zero-to-jupyterhub-k8s &&
     cd zero-to-jupyterhub-k8s &&
-    chartpress &&
-    git --no-pager diff
+    chartpress
+  - git --no-pager diff
   
-  - |-
-    chartpress --reset &&
-    git --no-pager diff
+  - chartpress --reset
+  - git --no-pager diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,21 +9,24 @@ script:
   - chartpress --version
   - chartpress --help
   - pyflakes .
-  - |
-    # This is a workaround to an issue caused by the existence of a docker registry
-    # mirror in our CI environment. Without this fix that removes the mirror,
-    # chartpress fails to realize the existence of already built images and rebuilds
-    # them.
-    #
-    # ref: https://github.com/moby/moby/issues/39120
-    echo '{"mtu": 1460}' | sudo dd of=/etc/docker/daemon.json
+
+  # This is a workaround to an issue caused by the existence of a docker registry
+  # mirror in our CI environment. Without this fix that removes the mirror,
+  # chartpress fails to realize the existence of already built images and rebuilds
+  # them.
+  #
+  # ref: https://github.com/moby/moby/issues/39120
+  - |-
+    echo '{"mtu": 1460}' | sudo dd of=/etc/docker/daemon.json &&
     sudo systemctl restart docker
-  - |
-    # run chartpress on zero-to-jupyterhub-k8s
-    git clone https://github.com/jupyterhub/zero-to-jupyterhub-k8s
-    cd zero-to-jupyterhub-k8s
-    chartpress
+
+  # run chartpress on zero-to-jupyterhub-k8s
+  - |-
+    git clone https://github.com/jupyterhub/zero-to-jupyterhub-k8s &&
+    cd zero-to-jupyterhub-k8s &&
+    chartpress &&
     git --no-pager diff
-  - |
-    chartpress --reset
+  
+  - |-
+    chartpress --reset &&
     git --no-pager diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Chart and image versioning, and Chart.yaml's --reset interaction [#52](https://github.com/jupyterhub/chartpress/pull/52) ([@consideRatio](https://github.com/consideRatio))
+
 Add --version flag [#45](https://github.com/jupyterhub/chartpress/pull/45) ([@consideRatio](https://github.com/consideRatio))
 
 ## 0.3

--- a/chartpress.py
+++ b/chartpress.py
@@ -425,7 +425,7 @@ def main():
             chart_version = chart_version.lstrip('v')
         if args.reset:
             chart_version = chart.get('resetTag', 'set-by-chartpress')
-        chart_version = build_chart(chart['name'], paths=chart_paths, version=chart_version, reset=args.reset)
+        chart_version = build_chart(chart['name'], paths=chart_paths, version=chart_version)
 
         if 'images' in chart:
             image_prefix = args.image_prefix if args.image_prefix is not None else chart['imagePrefix']

--- a/chartpress.py
+++ b/chartpress.py
@@ -310,11 +310,19 @@ def build_chart(name, version=None, paths=None, reset=False):
         if paths is None:
             paths = ['.']
         commit = last_modified_commit(*paths)
+        # parse prerelease version, preserving only the first part
+        # which will be the prerelease category (alpha, beta, etc.)
+        # if nothing is found, use `0`, to sort before alpha
+        base_version, *rest = chart['version'].split('-', 1)
+        prerelease = 0
+        if rest:
+            prerelease = rest[0].split('.')[0]
+            if not prerelease:
+                prerelease = '0'
 
-        if reset:
-            version = chart['version'].split('-')[0]
-        else:
-            version = chart['version'].split('-')[0] + '-' + commit
+        describe = check_output(['git', 'describe', '--tags', '--long', commit]).decode('utf8').strip()
+        _tag, n_commits, sha = describe.rsplit('-', 2)
+        version = "{base_version}-{prerelease}.{n_commits}.{sha}".format(**locals())
 
     chart['version'] = version
 

--- a/chartpress.py
+++ b/chartpress.py
@@ -64,7 +64,7 @@ def last_modified_commit(*paths, **kwargs):
         '--pretty=format:%h',
         '--',
         *paths
-    ], **kwargs).decode('utf-8')
+    ], **kwargs).decode('utf-8').strip()
 
 
 def last_modified_date(*paths, **kwargs):
@@ -77,7 +77,7 @@ def last_modified_date(*paths, **kwargs):
         '--date=iso',
         '--',
         *paths
-    ], **kwargs).decode('utf-8')
+    ], **kwargs).decode('utf-8').strip()
 
 
 def path_touched(*paths, commit_range):
@@ -237,7 +237,7 @@ def build_images(prefix, images, tag=None, commit_range=None, push=False, chart_
                     f'{chart_tag + ".." if chart_tag != "0.0.1" else ""}{last_image_commit}',
                 ],
                 echo=False,
-            ).decode('utf-8')
+            ).decode('utf-8').strip()
             image_tag = f"{chart_tag}_{n_commits}-{last_image_commit}"
         image_name = prefix + name
         image_spec = '{}:{}'.format(image_name, image_tag)
@@ -327,7 +327,7 @@ def build_chart(name, version=None, paths=None):
             n_commits = check_output(
                 ['git', 'rev-list', '--count', last_chart_commit],
                 echo=False,
-            ).decode('utf-8')
+            ).decode('utf-8').strip()
             version = f"0.0.1+{int(n_commits):03d}.{last_chart_commit}"
 
     chart['version'] = version


### PR DESCRIPTION
This is a continuation of @minrk's PR #33 where I implement my suggestion in https://github.com/jupyterhub/chartpress/pull/33#issuecomment-542196738.

1. I made the Chart version set itself prefixed with the latest tag found in the branch commit history instead of using a very specific manipulation of the value in Chart.yaml.
1. I made the Chart version set itself suffixed with `+<n_commits_since_tag>.<last_chart_modifying_commit>`, which results in a valid formatted SemVer 2 version.
1. I made the image tags follow the same pattern as the Chart version, but relating to the latest image commit instead of the latest chart commit. There is a difference, and that is that `+` is replaced with `_` to comply with the allowed characters of docker tags.
1. I made the Chart.yaml's `--reset` interaction be to reset the version field to something fixed. This closes #44 using the idea in https://github.com/jupyterhub/chartpress/issues/44#issuecomment-541005642. This change required the first point.

- I also fixed a failure to fail in our TravisCI test caused by multiline test commands that failed or succeeded only based on the last command, as compared to failing on any failure among the multiline commands.

---

## Example diff after chartpress is run on Z2JH

![image](https://user-images.githubusercontent.com/3837114/66954956-b1621580-f061-11e9-9c91-0f0145e9e888.png)

Note how it claims that the latest tag is 0.8.0, and that is actually true, it is the latest tagged commit in the git history of z2jh's master. For some reason, 0.8.1 and 0.8.2 tags commit not part of the master commit history. I consider this something that should be fixed in z2jh rather than adjust this PRs chartpress logic which I think makes sense.