### PR TITLE
Reset Chart.yaml's version to a valid value

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,12 @@ charts:
     # the prefix to use for built images
     imagePrefix: jupyterhub/k8s-
     # tag to use when resetting the chart values
-    # with --reset command-line option (defaults to "set-by-chartpress")
+    # with the --reset flag. It defaults to "set-by-chartpress".
     resetTag: latest
+    # version to use when resetting the Chart.yaml's version field with the
+    # --reset flag. It defaults to "0.0.1-set.by.chartpress". This is a valid
+    # SemVer 2 version, which is required for a helm lint command to succeed.
+    resetVersion: 1.2.3
     # the git repo whose gh-pages contains the charts
     repo:
       git: jupyterhub/helm-chart

--- a/chartpress.py
+++ b/chartpress.py
@@ -429,7 +429,7 @@ def main():
             # requirement on the version field.
             chart_version = chart_version.lstrip('v')
         if args.reset:
-            chart_version = chart.get('resetTag', 'set-by-chartpress')
+            chart_version = chart.get('resetVersion', '0.0.1-set.by.chartpress')
         chart_version = build_chart(chart['name'], paths=chart_paths, version=chart_version)
 
         if 'images' in chart:


### PR DESCRIPTION
If we reset this value to something else than a valid SemVer 2 version
string, then helm lint on the chart would fail. So, in this PR I make it default to `0.0.1-set.by.chartpress` which is a valid SemVer 2 version, and allow the user to customize this through `chartpress.yaml`'s resetVersion field.