### PR TITLE
--long flag to always output build information in image tags and chart version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,12 @@ script:
     cd zero-to-jupyterhub-k8s &&
     chartpress
   - git --no-pager diff
+
+  - chartpress --skip-build --tag 1.2.3-test.tag
+  - git --no-pager diff
+
+  - chartpress --long
+  - git --no-pager diff
   
   - chartpress --reset
   - git --no-pager diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - 3.6
 cache: pip
 install:
+  - set -e
   - pip install --upgrade pip
   - pip install pyflakes .
 script:
@@ -10,28 +11,41 @@ script:
   - chartpress --help
   - pyflakes .
 
-  # This is a workaround to an issue caused by the existence of a docker registry
-  # mirror in our CI environment. Without this fix that removes the mirror,
-  # chartpress fails to realize the existence of already built images and rebuilds
-  # them.
+  # This is a workaround to an issue caused by the existence of a docker
+  # registrymirror in our CI environment. Without this fix that removes the
+  # mirror, chartpress fails to realize the existence of already built images
+  # and rebuilds them.
   #
   # ref: https://github.com/moby/moby/issues/39120
   - |-
-    echo '{"mtu": 1460}' | sudo dd of=/etc/docker/daemon.json &&
-    sudo systemctl restart docker
+      echo '{"mtu": 1460}' | sudo dd of=/etc/docker/daemon.json &&
+      sudo systemctl restart docker &&
+      echo "Travis docker registry mirroring disabled.\n\n"
 
-  # run chartpress on zero-to-jupyterhub-k8s
   - |-
-    git clone https://github.com/jupyterhub/zero-to-jupyterhub-k8s &&
-    cd zero-to-jupyterhub-k8s &&
-    chartpress
-  - git --no-pager diff
+      git clone https://github.com/jupyterhub/zero-to-jupyterhub-k8s &&
+      cd zero-to-jupyterhub-k8s &&
+      chartpress &&
+      echo -e "\n\n### realistic run: expecting no rebuilds" &&
+      git --no-pager diff --unified=1
 
-  - chartpress --skip-build --tag 1.2.3-test.tag
-  - git --no-pager diff
+  - |-
+      chartpress --skip-build --tag 1.2.3-test.tag &&
+      echo -e "\n\n### --tag --skip-build: expecting no rebuilds and version 1.2.3-test.tag" &&
+      git --no-pager diff --unified=1
 
-  - chartpress --long
-  - git --no-pager diff
+  - |-
+      git tag -a 1.2.3-test.tag -m 1.2.3-test.tag HEAD &&
+      chartpress --skip-build &&
+      echo -e "\n\n### git tag: expecting version 1.2.3-test.tag" &&
+      git --no-pager diff --unified=1
+
+  - |-
+      chartpress --skip-build --long &&
+      echo -e "\n\n### --long: expecting version 1.2.3-test.tag+000.asdf1234" &&
+      git --no-pager diff --unified=1
   
-  - chartpress --reset
-  - git --no-pager diff
+  - |-
+      chartpress --reset &&
+      echo -e '\n\n### --reset: expecting version "0.0.1+set.by.chartpress"' &&
+      git --no-pager diff --unified=1

--- a/README.md
+++ b/README.md
@@ -79,29 +79,42 @@ In a directory containing a `chartpress.yaml`, run:
 to build your chart(s) and image(s). Add `--push` to publish images to docker hub and `--publish-chart` to publish the chart and index to gh-pages.
 
 ```
-usage: chartpress [-h] [--commit-range COMMIT_RANGE] [--push]
-                  [--publish-chart] [--tag TAG]
-                  [--extra-message EXTRA_MESSAGE]
+usage: chartpress [-h] [--push] [--publish-chart]
+                  [--extra-message EXTRA_MESSAGE] [--tag TAG | --long]
                   [--image-prefix IMAGE_PREFIX] [--reset] [--skip-build]
+                  [--version] [--commit-range COMMIT_RANGE]
 
 Automate building and publishing helm charts and associated images. This is
 used as part of the JupyterHub and Binder projects.
 
 optional arguments:
   -h, --help            show this help message and exit
-  --commit-range COMMIT_RANGE
-                        Range of commits to consider when building images
-  --push                Push built images to docker hub
-  --publish-chart       Publish updated chart to gh-pages
-  --tag TAG             Use this tag for images & charts
+  --push                Push built images to their docker image registry.
+  --publish-chart       Package a Helm chart and publish it to a Helm chart
+                        repository contructed with a GitHub git repository and
+                        GitHub pages.
   --extra-message EXTRA_MESSAGE
                         Extra message to add to the commit message when
-                        publishing charts
+                        publishing charts.
+  --tag TAG             Explicitly set the image tags and chart version.
+  --long                Use this to always get a build suffix for the
+                        generated tag and chart version, even when the
+                        specific commit has a tag.
   --image-prefix IMAGE_PREFIX
-                        Override image prefix with this value
-  --reset               Reset image tags
-  --skip-build          Skip image build, only render the charts
-  --version             Print current chartpress version
+                        Override the configured image prefix with this value.
+  --reset               Skip image build step and reset Chart.yaml's version
+                        field and values.yaml's image tags. What it resets to
+                        can be configured in chartpress.yaml with the resetTag
+                        and resetVersion configurations.
+  --skip-build          Skip the image build step.
+  --version             Print current chartpress version and exit.
+  --commit-range COMMIT_RANGE
+                        Deprecated: this flag will be ignored. The new logic
+                        to determine if an image needs to be rebuilt does not
+                        require this. It will find the time in git history
+                        where the image was last in need of a rebuild due to
+                        changes, and check if that build exists locally or
+                        remotely already.
 ```
 
 ### Caveats

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # chartpress
 
-Automate building and publishing helm charts and associated images.
+Automate building and publishing Helm charts and associated images.
 
 This is used as part of the JupyterHub and Binder projects.
 
-Chartpress will:
+Chartpress can:
 
-- build docker images and tag them with the latest git commit
-- publish those images to DockerHub
-- rerender a chart to include the tagged images
-- publish the chart and index to gh-pages
+- build docker images and tag them appropriately
+- push those images to a docker iamge repository
+- update Chart.yaml and values.yaml to reference the built images
+- publish the chart to a GitHub pages based Helm chart repository
+- reset Chart.yaml and values.yaml
 
-A `chartpress.yaml` file contains a specification of charts and images to build.
+A `chartpress.yaml` file contains a specification of charts and images to build
+for each chart.
 
 For example:
 
@@ -65,10 +67,12 @@ charts:
 ## Requirements
 
 The following binaries must be in your `PATH`:
-- git
-- helm
+- [git](https://www.git-scm.com/downloads)
+- [docker](https://docs.docker.com/install/#supported-platforms)
+- [helm](https://helm.sh/docs/using_helm/#installing-helm)
 
-If you are publishing a chart to GitHub Pages create a `gh-pages` branch in the destination repository.
+If you are publishing a chart to GitHub Pages create a `gh-pages` branch in the
+destination repository.
 
 ## Usage
 
@@ -76,7 +80,8 @@ In a directory containing a `chartpress.yaml`, run:
 
     chartpress
 
-to build your chart(s) and image(s). Add `--push` to publish images to docker hub and `--publish-chart` to publish the chart and index to gh-pages.
+to build your chart(s) and image(s). Add `--push` to publish images to docker
+hub and `--publish-chart` to publish the chart and index to gh-pages.
 
 ```
 usage: chartpress [-h] [--push] [--publish-chart]
@@ -121,11 +126,15 @@ optional arguments:
 
 #### Shallow clones
 
-Chartpress detects the latest commit which changed a directory or file when determining the tag to use for charts and images.
-This means that shallow clones should not be used because if the last commit that changed a relevant file is outside the shallow commit range, the wrong tag will be assigned.
+Chartpress detects the latest commit which changed a directory or file when
+determining the tag to use for charts and images. This means that shallow clones
+should not be used because if the last commit that changed a relevant file is
+outside the shallow commit range, the wrong tag will be assigned.
 
-Travis uses a clone depth of 50 by default, which can result in incorrect image tagging.
-You can [disable this shallow clone behavior](https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth) in your `.travis.yml`:
+Travis uses a clone depth of 50 by default, which can result in incorrect image
+tagging. You can [disable this shallow clone
+behavior](https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth)
+in your `.travis.yml`:
 
 ```yaml
 git:


### PR DESCRIPTION
This PR adds the `--long` flag to always output build information in image tags and chart version. This mimics `git describe --long` that has does something very similar.

The `--long` flag could be useful to avoid producing duplicate entries when a build job is run twice, once because of a commit was pushed, and once again because of a tag was pushed and coupled with this commit. If `--long` us used with pushed commits, but not for pushed tags or with `--tag`, then we wouldn't risk pushing two charts of the same version for example.

![chartpress-long-flag](https://user-images.githubusercontent.com/3837114/67095799-18451300-f1b7-11e9-9736-fbc9f1b224f0.gif)