### PR TITLE
support string images and items in lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ## 0.4
 
+### 0.4.3
+
+- Support `valuesPath` pointing to a single `image:tag` string in
+  addition to a dict with separate `repository` and `tag` keys.
+- Support lists in `valuesPath` by using integer indices,
+  e.g. `section.list.1.image` for the yaml:
+
+  ```yaml
+  section:
+    list:
+        - first: item
+          image: "not set"
+        - second: item
+          image: "image:tag"  #  <--sets this here
+  ```
+
+
 ### 0.4.2
 
 - --long flag to always output build information in image tags and chart version [#57](https://github.com/jupyterhub/chartpress/pull/57) ([@consideRatio](https://github.com/consideRatio))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@
   ```yaml
   section:
     list:
-        - first: item
-          image: "not set"
-        - second: item
-          image: "image:tag"  #  <--sets this here
+      - first: item
+        image: "not set"
+      - second: item
+        image: "image:tag"  #  <--sets this here
   ```
 
 

--- a/chartpress.py
+++ b/chartpress.py
@@ -277,6 +277,8 @@ def build_values(name, values_mods):
         values = yaml.load(f)
 
     for key, value in values_mods.items():
+        if not isinstance(value, dict) or set(value.keys()) != {'repository', 'tag'}:
+            raise ValueError(f"I only understand image updates with 'repository', 'tag', not: {value!r}")
         parts = key.split('.')
         mod_obj = parent = values
         for p in parts:
@@ -299,7 +301,7 @@ def build_values(name, values_mods):
                 )
 
             mod_obj['tag'] = value['tag']
-        elif isinstance(mod_obj, str) and set(value.keys()) == {'repository', 'tag'}:
+        elif isinstance(mod_obj, str):
             # scalar image string, not dict with separate repository, tag keys
             parent[parts[-1]] = "{repository}:{tag}".format(**value)
         else:

--- a/chartpress.py
+++ b/chartpress.py
@@ -278,8 +278,12 @@ def build_values(name, values_mods):
 
     for key, value in values_mods.items():
         parts = key.split('.')
-        mod_obj = values
+        mod_obj = parent = values
         for p in parts:
+            if p.isdigit():
+                # integers are indices in lists
+                p = int(p)
+            parent = mod_obj
             mod_obj = mod_obj[p]
         print(f"Updating {values_file}: {key}: {value}")
 
@@ -295,9 +299,12 @@ def build_values(name, values_mods):
                 )
 
             mod_obj['tag'] = value['tag']
+        elif isinstance(mod_obj, str) and set(value.keys()) == {'repository', 'tag'}:
+            # scalar image string, not dict with separate repository, tag keys
+            parent[parts[-1]] = "{repository}:{tag}".format(**value)
         else:
             raise TypeError(
-                f'The key {key} in {values_file} must be a mapping.'
+                f'The key {key} in {values_file} must be a mapping or string, not {type(mod_obj)}.'
             )
 
 


### PR DESCRIPTION
Decision is based on the type of the field being set. If `valuesPath` points to a dict, set it the current `repository:, tag:` way, if it's a string, set a single `repository:tag` image string.

enables e.g. using chartpress to build images in `profileList` in zero-to-jupyterhub:

```yaml
charts:
  - name: jupyterhub

    images:
      default:
        valuesPath: jupyterhub.singleuser.profileList.0.kubespawner_override.image
      gap:
        valuesPath: jupyterhub.singleuser.profileList.1.kubespawner_override.image
```

closes #10
closes #39 (edit by @consideRatio)