### PR TITLE
Fix bugs: index merge, image tag, g prefix, ignored tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ cache: pip
 install:
   - set -e
   - pip install --upgrade pip
-  - pip install pyflakes .
+  - pip install pyflakes pytest .
 script:
   - chartpress --version
   - chartpress --help
   - pyflakes .
+  - pytest -v ./tests
 
   # This is a workaround to an issue caused by the existence of a docker
   # registrymirror in our CI environment. Without this fix that removes the

--- a/README.md
+++ b/README.md
@@ -157,3 +157,19 @@ in your `.travis.yml`:
 git:
   depth: false
 ```
+
+## Development
+
+Testing of this python package can be done using [`pyflakes`](https://github.com/PyCQA/pyflakes) and [`pytest`](https://github.com/pytest-dev/pytest). There is also some additional testing that is only run as part of TravisCI, as declared in [`.travis.yml`](.travis.yml).
+
+```
+# install chartpress locally
+pip install  -e .
+
+# install dev dependencies
+pip install pyflakes pytest
+
+# run tests
+pyflakes .
+pytest -v
+```

--- a/chartpress.py
+++ b/chartpress.py
@@ -336,6 +336,9 @@ def build_chart(name, version=None, paths=None, long=False):
         try:
             git_describe = check_output(['git', 'describe', '--tags', '--long', last_chart_commit]).decode('utf8').strip()
             latest_tag_in_branch, n_commits, sha = git_describe.rsplit('-', maxsplit=2)
+            # remove the "g" prefix that is part of the git describe command
+            # ref: https://git-scm.com/docs/git-describe#_examples
+            sha = sha[1:]
 
             n_commits = int(n_commits)
             if n_commits > 0 or long:

--- a/chartpress.py
+++ b/chartpress.py
@@ -235,10 +235,10 @@ def build_images(prefix, images, tag=None, push=False, chart_tag=None, skip_buil
             if n_commits > 0 or long:
                 if "-" in chart_tag:
                     # append a pre-release
-                    image_tag = f"{chart_tag}.{n_commits:03d}-{last_image_commit}"
+                    image_tag = f"{chart_tag}.{n_commits:03d}.{last_image_commit}"
                 else:
                     # append a release
-                    image_tag = f"{chart_tag}-{n_commits:03d}-{last_image_commit}"
+                    image_tag = f"{chart_tag}-{n_commits:03d}.{last_image_commit}"
             else:
                 image_tag = f"{chart_tag}"
         image_name = prefix + name

--- a/tests/test_regexp.py
+++ b/tests/test_regexp.py
@@ -1,0 +1,14 @@
+from chartpress import _strip_identifiers_build_suffix
+from chartpress import _get_identifier
+
+def test__strip_identifiers_build_suffix():
+    assert _strip_identifiers_build_suffix(identifier="0.1.2-005.asdf1234") == "0.1.2"
+    assert _strip_identifiers_build_suffix(identifier="0.1.2-alpha.1.005.asdf1234") == "0.1.2-alpha.1"
+
+def test__get_identifier():
+    assert _get_identifier(tag="0.1.2",         n_commits="0", commit="asdf123",  long=True)  == "0.1.2-000.asdf123"
+    assert _get_identifier(tag="0.1.2",         n_commits="0", commit="asdf123",  long=False) == "0.1.2"
+    assert _get_identifier(tag="0.1.2",         n_commits="5", commit="asdf123",  long=False) == "0.1.2-005.asdf123"
+    assert _get_identifier(tag="0.1.2-alpha.1", n_commits="0", commit="asdf1234", long=True)  == "0.1.2-alpha.1.000.asdf1234"
+    assert _get_identifier(tag="0.1.2-alpha.1", n_commits="0", commit="asdf1234", long=False) == "0.1.2-alpha.1"
+    assert _get_identifier(tag="0.1.2-alpha.1", n_commits="5", commit="asdf1234", long=False) == "0.1.2-alpha.1.005.asdf1234"


### PR DESCRIPTION
## Key issue fixed: index merge
Closes #62 that followed an issue introduced by #52 by implementing https://github.com/jupyterhub/chartpress/issues/62#issuecomment-544377062 and catching some past mistakes of mine along the way. Fixing #62 is urgent as chartpress 0.4.2 is breaking expected functionality of chartpress.

### Additional issues fixed
- **image tag:** Found and fixed a bug from #62 relating to the use of `-` instead of `.` as separator for image tags, which was not according to plan or inline documentation.
- **g prefix:** Stripped away a "g" prefix that follows from use of git describe.
- **Ignored tags:** Fixed lacking ability to handle tags after latest modification commit, and renamed function to reflect this.

### Other
- Deleted a remnant function of past logic: `last_modified_date(*paths)`.
- Added pytest tests for simple to test functions `_get_identifier` and `_strip_identifiers_build_suffix`