### PR TITLE
Ensure to honor requirements.yaml before publishing a chart

### DIFF
--- a/chartpress.py
+++ b/chartpress.py
@@ -475,6 +475,7 @@ def publish_pages(chart_name, chart_version, chart_repo_github_path, chart_repo_
     with TemporaryDirectory() as td:
         check_call([
             'helm', 'package', chart_name,
+            '--dependency-update',
             '--destination', td + '/',
         ])
 


### PR DESCRIPTION
Closes https://github.com/jupyterhub/chartpress/issues/61.

In short, it makes sense to me to ensure that whatever is specified in the Helm chart's requirements.yaml is up to date with what is packaged.