### PR TITLE
[WIP] Preliminary check of chart publication

### DIFF
--- a/chartpress.py
+++ b/chartpress.py
@@ -322,7 +322,11 @@ def _get_published_chart_information(chart_repo_url, chart_name, chart_version):
     if not chart_releases:
         return None
 
-    matching_chart_release = dict(next((r for r in chart_releases if r["version"]==chart_version), {}))
+    matching_chart_release = None
+    for release in chart_releases:
+         if release["version"] == chart_version:
+            matching_chart_release = release
+            break
     return matching_chart_release
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,5 @@
+import pytest
+
 from chartpress import GITHUB_TOKEN_KEY
 
 from chartpress import git_remote
@@ -6,6 +8,7 @@ from chartpress import latest_tag_or_mod_commit
 from chartpress import render_build_args
 from chartpress import _strip_identifiers_build_suffix
 from chartpress import _get_identifier
+from chartpress import _get_published_chart_information
 
 from ruamel.yaml import YAML
 # use safe roundtrip yaml loader
@@ -66,3 +69,14 @@ def test_render_build_args(git_repo):
                 'TEST_STATIC_BUILD_ARG': 'test',
                 'TEST_DYNAMIC_BUILD_ARG': 'tag-sha',
             }
+
+@pytest.mark.parametrize(
+    "chart_repo_url,chart_name,chart_version",
+    [
+        ("https://jupyterhub.github.io/helm-chart", "jupyterhub", "0.8.2"),
+        ("https://jupyterhub.github.io/helm-chart/", "jupyterhub", "0.8.0-beta.1"),
+        pytest.param("https://jupyterhub.github.io/invalid-url", "jupyterhub", "0.8.2", marks=pytest.mark.xfail),
+    ],
+)
+def test__get_published_chart_information(chart_repo_url, chart_name, chart_version):
+    assert _get_published_chart_information(chart_repo_url, chart_name, chart_version)


### PR DESCRIPTION
I'm not sure what kind of usage experience we should aim for, but I know that I want to have chartpress help me perform checks if a helm chart has been published already. And I want to have this test be usuable to allow a CI system to skip tests if it wants to based on that, as well as be able to let chartpress only publish a chart if it isn't already published.

For example, in z2jh, when we don't make a change that affects the Helm chart, because we update the documentation only or similar, we don't need to run tests of the Helm chart. How would we like to use chartpress in those circumstances?

Here are some ideas of usage.

```shell
# stop early if chart version is published
# ...
# exit with what status code btw?
chartpress --exit-if-published

# print any published information about the chart if
# there is any, and exit like --version does after
chartpress --published-info
```

@sgibson91 @betatim @minrk, do you have ideas on how we design this kind of feature to be a useful and user friendly feature?