### PR TITLE
Update changelog for 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,28 @@
 
 ## Unreleased
 
-## 0.4
+## [0.5]
 
-### 0.4.3 (Breaking changes)
+### [0.5.0]
+
+#### Added
+
+- Add --force-build / --force-push, and don't let --tag imply it [#70](https://github.com/jupyterhub/chartpress/pull/70) ([@consideRatio](https://github.com/consideRatio))
+- `helm dependency update` is now run as part of publishing, this ensures we honor requirements.yaml before publishing a chart [#69](https://github.com/jupyterhub/chartpress/pull/69) ([@consideRatio](https://github.com/consideRatio))
+
+#### Fixes
+
+- Fix regression to make a chart's `images` configuration optional again [#77](https://github.com/jupyterhub/chartpress/pull/77) ([@jacobtomlinson](https://github.com/jacobtomlinson))
+- Fix regarding image paths as part of setting up thorough testing with PyTest [#68](https://github.com/jupyterhub/chartpress/pull/68) ([@consideRatio](https://github.com/consideRatio))
+
+#### Maintenance
+
+- Setup CD of PyPI releases on git tag pushes [#83](https://github.com/jupyterhub/chartpress/pull/83) ([@consideRatio](https://github.com/consideRatio))
+- Adopt bump2version for automating version bumps [#74](https://github.com/jupyterhub/chartpress/pull/74) ([@minrk](https://github.com/minrk))
+
+## [0.4]
+
+### [0.4.3] (Breaking changes)
 
 0.4.3 contains important bug fixes for versions `0.4.0` to `0.4.2`. A big bug
 fixed was that charts published using `--publish-chart` replaced previous charts
@@ -54,12 +73,12 @@ commits.
         image: "image:tag"  #  <--sets this here
   ```
 
-### 0.4.2 (broken)
+### [0.4.2] (broken)
 
 - --long flag to always output build information in image tags and chart version [#57](https://github.com/jupyterhub/chartpress/pull/57) ([@consideRatio](https://github.com/consideRatio))
 - Refactor publish_pages for comprehensibility [#56](https://github.com/jupyterhub/chartpress/pull/56) ([@consideRatio](https://github.com/consideRatio))
 
-### 0.4.1 (broken)
+### [0.4.1] (broken)
 
 - Deprecate --commit-range [#55](https://github.com/jupyterhub/chartpress/pull/55) ([@consideRatio](https://github.com/consideRatio))
 - Reset Chart.yaml's version to a valid value [#54](https://github.com/jupyterhub/chartpress/pull/54) ([@consideRatio](https://github.com/consideRatio))
@@ -70,41 +89,41 @@ commits.
 - Chart and image versioning, and Chart.yaml's --reset interaction [#52](https://github.com/jupyterhub/chartpress/pull/52) ([@consideRatio](https://github.com/consideRatio))
 - Add --version flag [#45](https://github.com/jupyterhub/chartpress/pull/45) ([@consideRatio](https://github.com/consideRatio))
 
-## 0.3
+## [0.3]
 
-### 0.3.2
+### [0.3.2]
 
 - Update chartpress --help output in README.md [#42](https://github.com/jupyterhub/chartpress/pull/42) ([@consideRatio](https://github.com/consideRatio))
 - Add initial setup when starting from scratch [#36](https://github.com/jupyterhub/chartpress/pull/36) ([@manics](https://github.com/manics))
 - avoid mangling of quotes in rendered charts (#1) [#34](https://github.com/jupyterhub/chartpress/pull/34) ([@rokroskar](https://github.com/rokroskar))
 - Add --skip-build and add --reset to reset image tags as well as chart version [#28](https://github.com/jupyterhub/chartpress/pull/28) ([@rokroskar](https://github.com/rokroskar))
 
-### 0.3.1
+### [0.3.1]
 
 - Fix conditionals for builds with new tagging scheme,
   by checking if images exist locally or on the registry
   rather than assuming the correct tag was pushed based on commit range.
 - Echo shell commands that are executed during the chartpress process
 
-### 0.3.0
+### [0.3.0]
 
 - Add chart version as prefix to image tags (e.g. 0.8-abc123)
 - Fix requires-python metadata to specify that Python 3.6 is required
 
-## 0.2
+## [0.2]
 
-### 0.2.2
+### [0.2.2]
 
 - Another ruamel.yaml type fix
 
-### 0.2.1
+### [0.2.1]
 
 - Add `--image-prefix` option
 - Workaround ruamel.yaml bug when strings are all-digits
   and start with 0 and contain an 8 or 9.
 - Fix type checking for recent ruamel.yaml
 
-### 0.2.0
+### [0.2.0]
 
 - Fix image tagging when building multiple images
 - Make image-building optional
@@ -113,12 +132,12 @@ commits.
 - Include chartpress.yaml when resolving last changed ref
 - Update only necessary fields
 
-## 0.1
+## [0.1]
 
-### 0.1.1
+### [0.1.1]
 
 - Add missing dependency on ruamel.yaml
 
-### 0.1.0
+### [0.1.0]
 
 first release!

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,9 +11,14 @@ For you to follow along according to these instructions, you need:
 
 ## Steps to make a release
 
-1. Update [CHANGELOG.md](CHANGELOG.md) if it is not up to date,
-   and verify [README.md](README.md) has an updated output of running `--help`.
-   Make a PR to review the CHANGELOG notes.
+1. Update [CHANGELOG.md](CHANGELOG.md) if it is not up to date, and verify
+   [README.md](README.md) has an updated output of running `--help`. Make a PR
+   to review the CHANGELOG notes.
+
+   To get the foundation of the changelog written, you can install
+   [github-activity](https://github.com/choldgraf/github-activity) and run
+   `github-activity --kind pr jupyterhub/chartpress` after setting up
+   credentials as described in the project's README.md file.
 
 1. Once the changelog is up to date, checkout master and make sure it is up to date and clean.
 


### PR DESCRIPTION
I'm not 100% on this, should I bump this to 0.5.0 because there are new features and minor tweaks of behavior, or make it 0.4.4 as it mainly fixes bugs and weird behavior?

This is what makes me thing it should be 0.5.0:
- Add --force-build / --force-push, and don't let --tag imply it [#70](https://github.com/jupyterhub/chartpress/pull/70) ([@consideRatio](https://github.com/consideRatio))
- `helm dependency update` is now run as part of publishing, this ensures we honor requirements.yaml before publishing a chart [#69](https://github.com/jupyterhub/chartpress/pull/69) ([@consideRatio](https://github.com/consideRatio))