### PR TITLE
Prefix build info with n and h to ensure SemVer 2 validity to solve Helm 3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ order that could come from using chartpress.
 
 ```
 0.8.0
-0.8.0-004.asdf123
-0.8.0-010.sdfg234
+0.8.0-n004.hasdf123
+0.8.0-n010.hsdfg234
 0.9.0-beta.1
-0.9.0-beta.1.001.dfgh345
-0.9.0-beta.1.005.fghj456
+0.9.0-beta.1.n001.hdfgh345
+0.9.0-beta.1.n005.hfghj456
 0.9.0-beta.2
-0.9.0-beta.2.001.ghjk567
+0.9.0-beta.2.n001.hghjk567
 0.9.0-beta.3
 0.9.0
 ```

--- a/chartpress.py
+++ b/chartpress.py
@@ -251,22 +251,24 @@ def _get_identifier(tag, n_commits, commit, long):
 
     This function should provide valid Helm chart versions, which means they
     need to be valid SemVer 2 version strings. It also needs to return valid
-    image tags, which means they need to not contain `+` signs either.
+    image tags, which means they need to not contain `+` signs either. We prefix
+    with n and h to ensure we don't get a numerical hash starting with 0 because
+    those are invalid SemVer 2 versions.
 
     Example:
         tag="0.1.2", n_commits="5", commit="asdf1234", long=True,
-        should return "0.1.2-005.asdf1234".
+        should return "0.1.2-n005.hasdf1234".
     """
     n_commits = int(n_commits)
 
     if n_commits > 0 or long:
         if "-" in tag:
             # append a pre-release tag, with a . separator
-            # 0.1.2-alpha.1 -> 0.1.2-alpha.1.n.sha
+            # 0.1.2-alpha.1 -> 0.1.2-alpha.1.n.h
             return f"{tag}.{n_commits:03d}.{commit}"
         else:
             # append a release tag, with a - separator
-            # 0.1.2 -> 0.1.2-n.sha
+            # 0.1.2 -> 0.1.2-n.h
             return f"{tag}-{n_commits:03d}.{commit}"
     else:
         return f"{tag}"
@@ -275,12 +277,12 @@ def _get_identifier(tag, n_commits, commit, long):
 def _strip_identifiers_build_suffix(identifier):
     """
     Return a stripped chart version or image tag (identifier) without its build
-    suffix (.005.asdf1234), leaving it to represent a Semver 2 release or
+    suffix (.n005.hasdf1234), leaving it to represent a Semver 2 release or
     pre-release.
 
     Example:
-        identifier: "0.1.2-005.asdf1234"            returns: "0.1.2"
-        identifier: "0.1.2-alpha.1.005.asdf1234"    returns: "0.1.2-alpha.1"
+        identifier: "0.1.2-n005.hasdf1234"            returns: "0.1.2"
+        identifier: "0.1.2-alpha.1.n005.hasdf1234"    returns: "0.1.2-alpha.1"
     """
     # split away official SemVer 2 build specifications if used
     if "+" in identifier:
@@ -322,11 +324,11 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, chart_v
 
         Example 1:
         - long=False: 0.9.0
-        - long=True:  0.9.0-000.asdf1234
+        - long=True:  0.9.0-n000.hasdf1234
 
         Example 2:
-        - long=False: 0.9.0-004.sdfg2345
-        - long=True:  0.9.0-004.sdfg2345
+        - long=False: 0.9.0-n004.hsdfg2345
+        - long=True:  0.9.0-n004.hsdfg2345
     """
     value_modifications = {}
     for name, options in images.items():
@@ -459,11 +461,11 @@ def build_chart(name, version=None, paths=None, long=False):
 
     Example versions constructed:
         - 0.9.0-alpha.1
-        - 0.9.0-alpha.1.000.asdf1234 (--long)
-        - 0.9.0-alpha.1.005.sdfg2345
-        - 0.9.0-alpha.1.005.sdfg2345 (--long)
+        - 0.9.0-alpha.1.n000.hasdf1234 (--long)
+        - 0.9.0-alpha.1.n005.hsdfg2345
+        - 0.9.0-alpha.1.n005.hsdfg2345 (--long)
         - 0.9.0
-        - 0.9.0-002.dfgh3456
+        - 0.9.0-n002.hdfgh3456
     """
     chart_file = os.path.join(name, 'Chart.yaml')
     with open(chart_file) as f:

--- a/chartpress.py
+++ b/chartpress.py
@@ -265,11 +265,11 @@ def _get_identifier(tag, n_commits, commit, long):
         if "-" in tag:
             # append a pre-release tag, with a . separator
             # 0.1.2-alpha.1 -> 0.1.2-alpha.1.n.h
-            return f"{tag}.{n_commits:03d}.{commit}"
+            return f"{tag}.n{n_commits:03d}.h{commit}"
         else:
             # append a release tag, with a - separator
             # 0.1.2 -> 0.1.2-n.h
-            return f"{tag}-{n_commits:03d}.{commit}"
+            return f"{tag}-n{n_commits:03d}.h{commit}"
     else:
         return f"{tag}"
 
@@ -291,7 +291,7 @@ def _strip_identifiers_build_suffix(identifier):
     # split away our custom build specification: something ending in either
     # . or - followed by three or more digits, a dot, an commit sha of four
     # or more alphanumeric characters.
-    return re.sub(r'[-\.]\d{3,}\.\w{4,}\Z', "", identifier)
+    return re.sub(r'[-\.]n\d{3,}\.h\w{4,}\Z', "", identifier)
 
 
 def build_images(prefix, images, tag=None, push=False, force_push=False, chart_version=None, force_build=False, skip_build=False, long=False):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -14,16 +14,16 @@ yaml.preserve_quotes = True ## avoid mangling of quotes
 yaml.indent(mapping=2, offset=2, sequence=4)
 
 def test__strip_identifiers_build_suffix():
-    assert _strip_identifiers_build_suffix(identifier="0.1.2-005.asdf1234") == "0.1.2"
-    assert _strip_identifiers_build_suffix(identifier="0.1.2-alpha.1.005.asdf1234") == "0.1.2-alpha.1"
+    assert _strip_identifiers_build_suffix(identifier="0.1.2-n005.hasdf1234") == "0.1.2"
+    assert _strip_identifiers_build_suffix(identifier="0.1.2-alpha.1.n005.hasdf1234") == "0.1.2-alpha.1"
 
 def test__get_identifier():
-    assert _get_identifier(tag="0.1.2",         n_commits="0", commit="asdf123",  long=True)  == "0.1.2-000.asdf123"
+    assert _get_identifier(tag="0.1.2",         n_commits="0", commit="asdf123",  long=True)  == "0.1.2-n000.hasdf123"
     assert _get_identifier(tag="0.1.2",         n_commits="0", commit="asdf123",  long=False) == "0.1.2"
-    assert _get_identifier(tag="0.1.2",         n_commits="5", commit="asdf123",  long=False) == "0.1.2-005.asdf123"
-    assert _get_identifier(tag="0.1.2-alpha.1", n_commits="0", commit="asdf1234", long=True)  == "0.1.2-alpha.1.000.asdf1234"
+    assert _get_identifier(tag="0.1.2",         n_commits="5", commit="asdf123",  long=False) == "0.1.2-n005.hasdf123"
+    assert _get_identifier(tag="0.1.2-alpha.1", n_commits="0", commit="asdf1234", long=True)  == "0.1.2-alpha.1.n000.hasdf1234"
     assert _get_identifier(tag="0.1.2-alpha.1", n_commits="0", commit="asdf1234", long=False) == "0.1.2-alpha.1"
-    assert _get_identifier(tag="0.1.2-alpha.1", n_commits="5", commit="asdf1234", long=False) == "0.1.2-alpha.1.005.asdf1234"
+    assert _get_identifier(tag="0.1.2-alpha.1", n_commits="5", commit="asdf1234", long=False) == "0.1.2-alpha.1.n005.hasdf1234"
 
 def test_git_remote(monkeypatch):
     monkeypatch.setenv(GITHUB_TOKEN_KEY, "test-github-token")

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -23,7 +23,7 @@ def test_chartpress_run(git_repo, capfd):
 
     # summarize information from git_repo
     sha = git_repo.commit("HEAD").hexsha[:7]
-    tag = f"0.0.1-001.{sha}"
+    tag = f"0.0.1-n001.h{sha}"
 
     # run chartpress
     out = _capture_output([], capfd)
@@ -79,8 +79,8 @@ def test_chartpress_run(git_repo, capfd):
 
     # verify usage of --long
     out = _capture_output(["--skip-build", "--long"], capfd)
-    assert f"Updating testchart/Chart.yaml: version: {tag}.000.{sha}" in out
-    assert f"Updating testchart/values.yaml: image: testchart/testimage:{tag}.000.{sha}" in out
+    assert f"Updating testchart/Chart.yaml: version: {tag}.n000.h{sha}" in out
+    assert f"Updating testchart/values.yaml: image: testchart/testimage:{tag}.n000.h{sha}" in out
 
 
     # verify usage of --image-prefix
@@ -141,7 +141,7 @@ def test_chartpress_run(git_repo, capfd):
     # verify output of --publish-chart
     assert "Branch 'gh-pages' set up to track remote branch 'gh-pages' from 'origin'." in out
     assert "Successfully packaged chart and saved it to:" in out
-    assert f"/testchart-{tag}.001.{sha}.tgz" in out
+    assert f"/testchart-{tag}.n001.h{sha}.tgz" in out
 
     # checkout gh-pages
     git_repo.git.stash()
@@ -156,7 +156,7 @@ def test_chartpress_run(git_repo, capfd):
     assert f"version: 1.2.1" in index_yaml
     assert f"version: 1.2.2" in index_yaml
     assert f"version: {tag}" in index_yaml
-    assert f"version: {tag}.001.{sha}" in index_yaml
+    assert f"version: {tag}.n001.h{sha}" in index_yaml
 
     # return to master
     git_repo.git.checkout("master")
@@ -188,7 +188,7 @@ def test_chartpress_paths_configuration(git_repo, capfd):
     open("not-in-paths.txt", "w").close()
     git_repo.git.add(all=True)
     sha = git_repo.index.commit("Added not-in-paths.txt").hexsha[:7]
-    tag = f"0.0.1-002.{sha}"
+    tag = f"0.0.1-n002.h{sha}"
     out = _capture_output(["--skip-build"], capfd)
     assert f"Updating testchart/Chart.yaml: version: {tag}" not in out
     assert f"Updating testchart/values.yaml: image: testchart/testimage:{tag}" not in out
@@ -200,7 +200,7 @@ def test_chartpress_paths_configuration(git_repo, capfd):
     open("extra-chart-path.txt", "w").close()
     git_repo.git.add(all=True)
     sha = git_repo.index.commit("Added extra-chart-path.txt").hexsha[:7]
-    tag = f"0.0.1-003.{sha}"
+    tag = f"0.0.1-n003.h{sha}"
     out = _capture_output(["--skip-build"], capfd)
     assert f"Updating testchart/Chart.yaml: version: {tag}" in out
     assert f"Updating testchart/values.yaml: image: testchart/testimage:{tag}" not in out
@@ -210,7 +210,7 @@ def test_chartpress_paths_configuration(git_repo, capfd):
     open("extra-image-path.txt", "w").close()
     git_repo.git.add(all=True)
     sha = git_repo.index.commit("Added extra-image-path.txt").hexsha[:7]
-    tag = f"0.0.1-004.{sha}"
+    tag = f"0.0.1-n004.h{sha}"
     out = _capture_output(["--skip-build"], capfd)
     assert f"Updating testchart/Chart.yaml: version: {tag}" in out
     assert f"Updating testchart/values.yaml: image: testchart/testimage:{tag}" in out
@@ -224,7 +224,7 @@ def test_chartpress_run_bare_minimum(git_repo_bare_minimum, capfd):
     """
     r = git_repo_bare_minimum
     sha = r.heads.master.commit.hexsha[:7]
-    tag = f"0.0.1-002.{sha}"
+    tag = f"0.0.1-n002.h{sha}"
 
     out = _capture_output([], capfd)
     assert f"Updating testchart/Chart.yaml: version: {tag}" in out


### PR DESCRIPTION
Fixes #86 with 14f44dc + test updates.

In short, we now make `0.9.0-alpha.1.095.123asdf` become `0.9.0-alpha.1.n095.h123asdf` to ensure we never have a numerical identifier with a leading zero, which is breaking Helm 3 usage of our chart because its dependency masterminds/semver now does a better job verifying if the version is a valid semver version etc.

I failed to spot the suggested version with a leading zero in a fully numerical identifier wasn't a valid semver version before =/

This will need a minor version bump for a release, and could once again cause issues from chartpress that @henchc @betatim has helped worked through in the past for binderhub and mybinder.org.