### PR TITLE
support overriding imageName

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,12 @@ charts:
     # images to build for this chart (optional)
     images:
       binderhub:
-        # Template docker build arguments to be passed using docker's
-        # --build-arg flag as --build-arg <key>=<value>. Available dynamic
-        # values are TAG and LAST_COMMIT.
+        # imageName overrides the default name of the image. The default name
+        # is the imagePrefix augmented with the key of this configuration. It
+        # would be jupyterhub/k8s-binderhub in this case.
+        imageName: jupyterhub/k8s-custom-image-name
+        # Build arguments to be passed using docker's --build-arg flag as
+        # --build-arg <key>=<value>. TAG and LAST_COMMIT are expandable.
         buildArgs:
           MY_STATIC_BUILD_ARG: "hello world"
           MY_DYNAMIC_BUILD_ARG: "{TAG}-{LAST_COMMIT}"

--- a/chartpress.py
+++ b/chartpress.py
@@ -357,7 +357,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, chart_v
         image_name = options.get('imageName', prefix + name)
         image_spec = '{}:{}'.format(image_name, image_tag)
 
-        values_path_list = options['valuesPath']
+        values_path_list = options.get('valuesPath', [])
         if isinstance(values_path_list, str):
             # single path, wrap it in a list
             values_path_list = [values_path_list]
@@ -708,7 +708,7 @@ def main(args=None):
         chart_version = build_chart(chart['name'], paths=chart_paths, version=chart_version, long=args.long)
 
         if 'images' in chart:
-            image_prefix = args.image_prefix if args.image_prefix is not None else chart['imagePrefix']
+            image_prefix = args.image_prefix or chart.get('imagePrefix', '')
             value_mods = build_images(
                 prefix=image_prefix,
                 images=chart['images'],

--- a/chartpress.py
+++ b/chartpress.py
@@ -354,7 +354,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, chart_v
                 echo=False,
             ).decode('utf-8').strip()
             image_tag = _get_identifier(chart_version, n_commits, image_commit, long)
-        image_name = prefix + name
+        image_name = options.get('imageName', prefix + name)
         image_spec = '{}:{}'.format(image_name, image_tag)
 
         values_path_list = options['valuesPath']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,19 @@ def git_repo_bare_minimum(monkeypatch, git_repo):
     shutil.move("chartpress_bare_minimum.yaml", "chartpress.yaml")
     shutil.rmtree("image")
     r.git.add(all=True)
-    r.index.commit("bare minimum commit")
+    r.index.commit("chartpress_bare_minimum.yaml initial commit")
+
+    yield r
+
+@pytest.fixture(scope="function")
+def git_repo_alternative(monkeypatch, git_repo):
+    """
+    This fixture modifies the default git_repo fixture to use another the
+    chartpress_alternative.yaml as chartpress.yaml.
+    """
+    r = git_repo
+    shutil.move("chartpress_alternative.yaml", "chartpress.yaml")
+    r.git.add(all=True)
+    r.index.commit("chartpress_alternative.yaml initial commit")
 
     yield r

--- a/tests/test_helm_chart/chartpress_alternative.yaml
+++ b/tests/test_helm_chart/chartpress_alternative.yaml
@@ -1,0 +1,6 @@
+charts:
+  - name: testchart
+    images:
+      testimage:
+        imageName: test-image-name-configuration
+        contextPath: image

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -230,6 +230,20 @@ def test_chartpress_run_bare_minimum(git_repo_bare_minimum, capfd):
     assert f"Updating testchart/Chart.yaml: version: {tag}" in out
 
 
+def test_chartpress_run_alternative(git_repo_alternative, capfd):
+    """
+    Ensures that chartpress will run with an alternative configuration. This
+    allow us to test against more kinds of configurations than we could squeeze
+    into a single chartpress.yaml file.
+    """
+    r = git_repo_alternative
+    sha = r.heads.master.commit.hexsha[:7]
+    tag = f"0.0.1-n002.h{sha}"
+
+    out = _capture_output([], capfd)
+    assert f"Successfully tagged test-image-name-configuration:{tag}" in out
+
+
 def _capture_output(args, capfd):
     """
     Calls chartpress given provided arguments and captures the output during the


### PR DESCRIPTION
Allows building individual images without the prefix+name structure

in nbviewer, I want to build `jupyter/nbviewer` and `jupyter/nbviewer-statuspage`, but use `jupyter/nbviewer-` as prefix.

I know I *can* use `jupyter/` as prefix and hve image names `nbviewer`, `nbviewer-statuspage`, but this seems like something that might come up again.