### PR TITLE
CI: publish tags without tests and test python 3.6-3.8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+select = F
+ignore = E,W,C,F401,F841,F541

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
   - helm version --client
   - chartpress --version
   - chartpress --help
-  - pytest --verbose --flakes
+  - pytest --verbose --flake8
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
+os: linux
 dist: bionic
 language: python
-python:
-  - 3.6
+
+stages:
+  - name: test
+    if: tag IS NOT present
+  - name: publish
+    if: tag IS present
+
 install:
   - set -e
   - pip install --upgrade pip
@@ -32,16 +38,20 @@ script:
 
 jobs:
   include:
-    # Default stage: test
-    - name: Helm 2
-    - name: Helm 3
+    - name: Helm 2, Python 3.6
+      python: 3.6
       before_script:
         # Install helm2 instead of helm3
         - curl -L https://git.io/get_helm.sh | bash
         - helm init --client-only
-    # Only deploy if all test jobs passed
-    - stage: deploy
-      if: tag IS present
+
+    - name: Helm 3, Python 3.7
+      python: 3.7
+
+    - name: Helm 3, Python 3.8
+      python: 3.8
+
+    - stage: publish
       deploy:
         provider: pypi
         user: "__token__"
@@ -53,3 +63,7 @@ jobs:
           # the master branch. A tag does not belong specifically to a branch, so
           # without this it would fail to deploy for tags.
           tags: true
+        before_script:
+          - echo "Required dummy override of default 'before_script' in .travis.yml."
+        script:
+          - echo "Required dummy override of default 'script' in .travis.yml."

--- a/README.md
+++ b/README.md
@@ -233,5 +233,5 @@ pip install  -e .
 pip install -r dev-requirements.txt
 
 # run tests
-pytest --verbose --flakes --exitfirst
+pytest --verbose --flake8 --exitfirst
 ```

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 bump2version
 gitpython
 pytest
-pytest-flakes
+pytest-flake8

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,16 +2,15 @@
 
 These tests are [pytest](https://docs.pytest.org) tests.
 
-
 ```bash
-pytest -vx --flakes
+pytest -vx --flake8
 
 # -v / --verbose:
 #   allows you to see the names etc of individual tests etc.
 # -x / --exitfirst:
 #   to stop running tests of first error
-# --flakes:
-#   use pyflakes to add some static code analysis tests
+# --flake8:
+#   use pytest-flake8 to add some static code analysis tests
 # -k:
 #   only run tests which match the given substring
 ```
@@ -23,7 +22,7 @@ pytest -vx --flakes
 - [pytest](https://docs.pytest.org)
   - Fixture: [capfd](https://docs.pytest.org/en/latest/reference.html#_pytest.capture.capfd)
   - Fixture: [monkeypatching](https://docs.pytest.org/en/latest/capfd.html)
-- [pytest-flakes](https://github.com/fschulze/pytest-flakes) and
+- [pytest-flake8](https://github.com/fschulze/pytest-flakes) and
   [pyflakes](https://github.com/PyCQA/pyflakes) for passive code check tests
   added to the other pytest tests when using the `--flakes` flag with `pytest`.
 - [GitPython](https://gitpython.readthedocs.io/en/stable/)


### PR DESCRIPTION
This is following discussion in https://github.com/jupyterhub/team-compass/issues/317.

I also needed to solve a test error relating to flake8. In doing so I updated to use pytest-flake8 instead of pytest-flakes which seemed outdated and didn't allow me to configure flake8 in a flake8 native way which I liked a lot more than introducing some custom way to configure things.