### PR TITLE
add chartpress --list-images

### DIFF
--- a/chartpress.py
+++ b/chartpress.py
@@ -49,7 +49,11 @@ def run_cmd(call, cmd, *, echo=True, **kwargs):
     return call(cmd, **kwargs)
 
 
-check_call = partial(run_cmd, subprocess.check_call, stdout=sys.stderr)
+def check_call(cmd, **kwargs):
+    kwargs.setdefault("stdout", sys.stderr.fileno())
+    return run_cmd(subprocess.check_call, cmd, **kwargs)
+
+
 check_output = partial(run_cmd, subprocess.check_output)
 
 

--- a/chartpress.py
+++ b/chartpress.py
@@ -668,12 +668,17 @@ def main(args=None):
         action='store_true',
         help='Enforce the image build step, regardless of if the image already is available either locally or remotely.',
     )
+
+    argparser.add_argument(
+        "--list-images",
+        action="store_true",
+        help="print list of images to stdout. Images will not be built.",
+    )
     argparser.add_argument(
         '--version',
         action='store_true',
         help='Print current chartpress version and exit.',
     )
-
     argparser.add_argument(
         '--commit-range',
         action=ActionStoreDeprecated,
@@ -685,6 +690,9 @@ def main(args=None):
     if args.version:
         print(f"chartpress version {__version__}")
         return
+
+    if args.list_images:
+        args.skip_build = True
 
     with open('chartpress.yaml') as f:
         config = yaml.load(f)
@@ -729,6 +737,15 @@ def main(args=None):
                 skip_build=args.skip_build or args.reset,
                 long=args.long,
             )
+            if args.list_images:
+                seen_images = set()
+                for key, image_dict in value_mods.items():
+                    image = "{repository}:{tag}".format(**image_dict)
+                    if image not in seen_images:
+                        print(image)
+                        # record image, in case the same image occurs in multiple places
+                        seen_images.add(image)
+                return
             build_values(chart['name'], value_mods)
 
         if args.publish_chart:

--- a/tests/test_chartpress.py
+++ b/tests/test_chartpress.py
@@ -1,0 +1,20 @@
+import sys
+from subprocess import run
+
+
+def test_list_images(git_repo):
+    p = run(
+        [sys.executable, "-m", "chartpress", "--list-images"],
+        check=True,
+        capture_output=True,
+    )
+    stdout = p.stdout.decode("utf8").strip()
+    # echo stdout/stderr for debugging
+    sys.stderr.write(p.stderr.decode("utf8", "replace"))
+    sys.stdout.write(stdout)
+
+    images = stdout.strip().splitlines()
+    assert len(images) == 1
+    # split hash_suffix which will be different every run
+    pre_hash, hash_suffix = images[0].rsplit(".", 1)
+    assert pre_hash == "testchart/testimage:0.0.1-n001"

--- a/tests/test_chartpress.py
+++ b/tests/test_chartpress.py
@@ -1,12 +1,13 @@
 import sys
-from subprocess import run
+from subprocess import run, PIPE
 
 
 def test_list_images(git_repo):
     p = run(
         [sys.executable, "-m", "chartpress", "--list-images"],
         check=True,
-        capture_output=True,
+        stdout=PIPE,
+        stderr=PIPE,
     )
     stdout = p.stdout.decode("utf8").strip()
     # echo stdout/stderr for debugging

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -1,6 +1,8 @@
 import os
+import sys
 
 import chartpress
+
 
 def test_git_repo_fixture(git_repo):
     # assert we use the git repo as our current working directory
@@ -27,7 +29,7 @@ def test_chartpress_run(git_repo, capfd):
 
     # run chartpress
     out = _capture_output([], capfd)
-    
+
     # verify image was built
     # verify the fallback tag of "0.0.1" when a tag is missing
     assert f"Successfully tagged testchart/testimage:{tag}" in out
@@ -244,7 +246,7 @@ def test_chartpress_run_alternative(git_repo_alternative, capfd):
     assert f"Successfully tagged test-image-name-configuration:{tag}" in out
 
 
-def _capture_output(args, capfd):
+def _capture_output(args, capfd, expect_output=False):
     """
     Calls chartpress given provided arguments and captures the output during the
     call.
@@ -260,6 +262,8 @@ def _capture_output(args, capfd):
     _, _ = capfd.readouterr()
     chartpress.main(args)
     out, err = capfd.readouterr()
+    if not expect_output:
+        assert out == ""
 
     # since the output was captured, print it back out again for debugging
     # purposes if a test fails for example
@@ -267,6 +271,9 @@ def _capture_output(args, capfd):
     footer = "-" * len(header)
     print()
     print(header)
+    print("out:")
     print(out)
+    print("err:")
+    print(err, file=sys.stderr)
     print(footer)
-    return out
+    return err


### PR DESCRIPTION
outputs list of images to stdout. Listing images implies skip-build.

for convenient consumption of the list of images, e.g. to pass to trivy for security scans

To make chartpress output pipeable, send all log messages to stderr instead of stdout, as is standard practice.

I think this closes #94 unless I misunderstood the goal there.

Since this does move prevous output to stderr, if anyone was relying on chartpress stdout, this could be considered a backward-incompatible change. But since our output was not really machine-readable, I'd call this a minor revision.