### PR TITLE
Add --force-publish-chart and default to not overwriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ hub and `--publish-chart` to publish the chart and index to gh-pages.
 
 ```
 usage: chartpress [-h] [--push] [--force-push] [--publish-chart]
-                  [--extra-message EXTRA_MESSAGE] [--tag TAG | --long]
-                  [--image-prefix IMAGE_PREFIX] [--reset]
-                  [--skip-build | --force-build] [--version]
+                  [--force-publish-chart] [--extra-message EXTRA_MESSAGE]
+                  [--tag TAG | --long] [--image-prefix IMAGE_PREFIX] [--reset]
+                  [--skip-build | --force-build] [--list-images] [--version]
                   [--commit-range COMMIT_RANGE]
 
 Automate building and publishing helm charts and associated images. This is
@@ -101,8 +101,14 @@ optional arguments:
   --force-push          Push built images to their image registries,
                         regardless if it would replace an existing image.
   --publish-chart       Package a Helm chart and publish it to a Helm chart
-                        repository contructed with a GitHub git repository and
-                        GitHub pages.
+                        registry constructed with a GitHub git repository and
+                        GitHub pages, but not if it would replace an existing
+                        chart version.
+  --force-publish-chart
+                        Package a Helm chart and publish it to a Helm chart
+                        registry constructed with a GitHub git repository and
+                        GitHub pages, regardless if it would replace an
+                        existing chart version
   --extra-message EXTRA_MESSAGE
                         Extra message to add to the commit message when
                         publishing charts.
@@ -119,6 +125,8 @@ optional arguments:
   --skip-build          Skip the image build step.
   --force-build         Enforce the image build step, regardless of if the
                         image already is available either locally or remotely.
+  --list-images         print list of images to stdout. Images will not be
+                        built.
   --version             Print current chartpress version and exit.
   --commit-range COMMIT_RANGE
                         Deprecated: this flag will be ignored. The new logic

--- a/chartpress.py
+++ b/chartpress.py
@@ -70,9 +70,8 @@ def git_remote(git_repo):
 
     github_token = os.getenv(GITHUB_TOKEN_KEY)
     if github_token:
-        return 'https://{0}@github.com/{1}'.format(
-            github_token, git_repo)
-    return 'git@github.com:{0}'.format(git_repo)
+        return f'https://{github_token}@github.com/{git_repo}'
+    return f'git@github.com:{git_repo}'
 
 
 @lru_cache()
@@ -206,7 +205,7 @@ def build_image(image_spec, context_path, dockerfile_path=None, build_args=None)
     if dockerfile_path:
         cmd.extend(['-f', dockerfile_path])
     for k, v in (build_args or {}).items():
-        cmd += ['--build-arg', '{}={}'.format(k, v)]
+        cmd += ['--build-arg', f'{k}={v}']
     check_call(cmd)
 
 @lru_cache()
@@ -383,7 +382,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, chart_v
             ).decode('utf-8').strip()
             image_tag = _get_identifier(chart_version, n_commits, image_commit, long)
         image_name = options.get('imageName', prefix + name)
-        image_spec = '{}:{}'.format(image_name, image_tag)
+        image_spec = f'{image_name}:{image_tag}'
 
         values_path_list = options.get('valuesPath', [])
         if isinstance(values_path_list, str):
@@ -537,7 +536,7 @@ def build_chart(name, version=None, paths=None, long=False):
     return version
 
 
-def publish_pages(chart_name, chart_version, chart_repo_github_path, chart_repo_url, extra_message=''):
+def publish_pages(chart_name, chart_version, chart_repo_github_path, chart_repo_url, extra_message="", force=False):
     """
     Update a Helm chart registry hosted in the gh-pages branch of a GitHub git
     repository.
@@ -546,13 +545,15 @@ def publish_pages(chart_name, chart_version, chart_repo_github_path, chart_repo_
 
     1. Clone the Helm chart registry as found in the gh-pages branch of a git
        reposistory.
-    2. Create a temporary directory and `helm package` the chart into a file
+    2. If --force-publish-chart isn't specified, then verify that we won't
+       overwrite an existing chart version.
+    3. Create a temporary directory and `helm package` the chart into a file
        within this temporary directory now only containing the chart .tar file.
-    3. Generate a index.yaml with `helm repo index` based on charts found in the
+    4. Generate a index.yaml with `helm repo index` based on charts found in the
        temporary directory folder (a single one), and then merge in the bigger
        and existing index.yaml from the cloned Helm chart registry using the
        --merge flag.
-    4. Copy the new index.yaml and packaged Helm chart .tar into the gh-pages
+    5. Copy the new index.yaml and packaged Helm chart .tar into the gh-pages
        branch, commit it, and push it back to the origin remote.
 
     Note that if we would add the new chart .tar file next to the other .tar
@@ -566,19 +567,37 @@ def publish_pages(chart_name, chart_version, chart_repo_github_path, chart_repo_
     this, it is as we would have a --force-publish-chart by default.
     """
 
-    # clone the Helm chart repo and checkout its gh-pages branch,
-    # note the use of cwd (current working directory)
-    checkout_dir = '{}-{}'.format(chart_name, chart_version)
-    check_call(
-        [
-            'git', 'clone', '--no-checkout',
-            git_remote(chart_repo_github_path),
-            checkout_dir,
-        ],
-        # warning: if echoed, this call could reveal the github token
-        echo=True,
-    )
+    # clone/fetch the Helm chart repo and checkout its gh-pages branch, note the
+    # use of cwd (current working directory)
+    checkout_dir = f'{chart_name}-{chart_version}'
+    if not os.path.isdir(checkout_dir):
+        check_call(
+            [
+                'git', 'clone', '--no-checkout',
+                git_remote(chart_repo_github_path),
+                checkout_dir,
+            ],
+            # warning: if echoed, this call could reveal the github token
+            echo=True,
+        )
+    else:
+        check_call(['git', 'fetch'], cwd=checkout_dir, echo=True)
     check_call(['git', 'checkout', 'gh-pages'], cwd=checkout_dir, echo=True)
+
+    # check if there is any already published chart with chart_name
+    # and chart_version and make a decision based on the --force-publish-chart
+    # flag if that is the case, but always log what's done
+    if os.path.isfile(os.path.join(checkout_dir, 'index.yaml')):
+        with open(os.path.join(checkout_dir, 'index.yaml')) as f:
+            chart_repo_index = yaml.load(f)
+            published_charts = chart_repo_index["entries"].get(chart_name)
+
+        if any(c["version"] == chart_version for c in published_charts):
+            if force:
+                log(f"Chart of version {chart_version} already exists, overwriting it.")
+            else:
+                log(f"Skipping chart publishing of version {chart_version}, it is already published")
+                return
 
     # package the latest version into a temporary directory
     # and run helm repo index with --merge to update index.yaml
@@ -648,7 +667,12 @@ def main(args=None):
     argparser.add_argument(
         '--publish-chart',
         action='store_true',
-        help='Package a Helm chart and publish it to a Helm chart registry contructed with a GitHub git repository and GitHub pages.',
+        help='Package a Helm chart and publish it to a Helm chart registry constructed with a GitHub git repository and GitHub pages, but not if it would replace an existing chart version.',
+    )
+    argparser.add_argument(
+        '--force-publish-chart',
+        action='store_true',
+        help='Package a Helm chart and publish it to a Helm chart registry constructed with a GitHub git repository and GitHub pages, regardless if it would replace an existing chart version',
     )
     argparser.add_argument(
         '--extra-message',
@@ -767,13 +791,14 @@ def main(args=None):
                 return
             build_values(chart['name'], value_mods)
 
-        if args.publish_chart:
+        if args.publish_chart or args.force_publish_chart:
             publish_pages(
                 chart_name=chart['name'],
                 chart_version=chart_version,
                 chart_repo_github_path=chart['repo']['git'],
                 chart_repo_url=chart['repo']['published'],
                 extra_message=args.extra_message,
+                force=args.force_publish_chart,
             )
 
 

--- a/chartpress.py
+++ b/chartpress.py
@@ -61,6 +61,12 @@ def git_remote(git_repo):
     """Return the URL for remote git repository.
 
     Depending on the system setup it returns ssh or https remote.
+
+    FIXME: We provide a remote url with a secret GITHUB_TOKEN inside it. This is
+           retained in the cloned repository later. All this combined makes for
+           a unexpected result in my mind where having used ` GITHUB_TOKEN=asdf
+           chartpress --publish-chart` would make you permanently stored the
+           GITHUB_TOKEN on disk.
     """
     # if not matching something/something
     # such as a local directory ".", then
@@ -577,8 +583,10 @@ def publish_pages(chart_name, chart_version, chart_repo_github_path, chart_repo_
                 git_remote(chart_repo_github_path),
                 checkout_dir,
             ],
-            # warning: if echoed, this call could reveal the github token
-            echo=True,
+            # FIXME: We want to echo this I think, but... When we use
+            #        GITHUB_TOKEN, we cannot echo the command securly, because
+            #        git_remote(chart_repo_github_path) will contain it.
+            echo=False,
         )
     else:
         check_call(['git', 'fetch'], cwd=checkout_dir, echo=True)

--- a/chartpress.py
+++ b/chartpress.py
@@ -584,7 +584,8 @@ def publish_pages(chart_name, chart_version, chart_repo_github_path, chart_repo_
         check_call(['git', 'fetch'], cwd=checkout_dir, echo=True)
     check_call(['git', 'checkout', 'gh-pages'], cwd=checkout_dir, echo=True)
 
-    # check if there is any already published chart with chart_name
+    # check if a chart with the same name and version has already been published. If
+    # there is, the behaviour depends on `-force-publish-chart`
     # and chart_version and make a decision based on the --force-publish-chart
     # flag if that is the case, but always log what's done
     if os.path.isfile(os.path.join(checkout_dir, 'index.yaml')):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -4,6 +4,7 @@ from chartpress import git_remote
 from chartpress import image_needs_pushing
 from chartpress import latest_tag_or_mod_commit
 from chartpress import render_build_args
+from chartpress import check_call
 from chartpress import _strip_identifiers_build_suffix
 from chartpress import _get_identifier
 
@@ -31,6 +32,12 @@ def test_git_remote(monkeypatch):
 
     monkeypatch.delenv(GITHUB_TOKEN_KEY)
     assert git_remote("jupyterhub/helm-chart") == "git@github.com:jupyterhub/helm-chart"
+
+def test_git_token_censoring(monkeypatch, capfd):
+    monkeypatch.setenv(GITHUB_TOKEN_KEY, "secret-token-not-to-be-exposed-in-logs")
+    check_call(["echo", "Non failing dummy command with secret-token-not-to-be-exposed-in-logs"])
+    _, err = capfd.readouterr()
+    assert "CENSORED_GITHUB_TOKEN" in err
 
 def test_image_needs_pushing():
     assert image_needs_pushing("jupyterhub/image-not-to-be-found:latest")

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -136,9 +136,20 @@ def test_chartpress_run(git_repo, capfd):
         ],
         capfd,
     )
-
     # verify output of --publish-chart
     assert f"Skipping chart publishing" in out
+
+    # verify usage of --force-publish-chart when the chart version exists in the
+    # chart repo already
+    out = _capture_output(
+        [
+            "--skip-build",
+            "--force-publish-chart",
+        ],
+        capfd,
+    )
+    # verify output of --force-publish-chart
+    assert f"already exists, overwriting it" in out
 
 
 

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -127,8 +127,23 @@ def test_chartpress_run(git_repo, capfd):
     git_repo.git.stash("pop")
 
 
+    # verify usage of --publish-chart when the chart version exists in the chart
+    # repo already
+    out = _capture_output(
+        [
+            "--skip-build",
+            "--publish-chart",
+        ],
+        capfd,
+    )
+
+    # verify output of --publish-chart
+    assert f"Skipping chart publishing" in out
+
+
+
     # verify we don't overwrite the previous version when we make dev commits
-    # and use --publish-chart
+    # and use --publish-chart and that we don't skip publishing
     open("extra-chart-path.txt", "w").close()
     git_repo.git.add(all=True)
     sha = git_repo.index.commit("Added extra-chart-path.txt").hexsha[:7]
@@ -144,6 +159,7 @@ def test_chartpress_run(git_repo, capfd):
     assert "Branch 'gh-pages' set up to track remote branch 'gh-pages' from 'origin'." in out
     assert "Successfully packaged chart and saved it to:" in out
     assert f"/testchart-{tag}.n001.h{sha}.tgz" in out
+    assert f"Skipping chart publishing" not in out
 
     # checkout gh-pages
     git_repo.git.stash()


### PR DESCRIPTION
This feature help us avoid publishing the same chart version twice unless `--force-publish-chart` is passed. This mirrors the `--push` and `--force-push` behavior of docker images.

There are several reasons to not push an already existing chart:
1. It can trigger other pointless actions, such as henchbot suggesting mybinder.org-deploy to update.
2. It will clutter the gh-pages branch of the helm-chart git repository we push to. This clutter is both visual for any user browsing the versions and makes the helm chart repo grow bigger and bigger.

Closes #60 (the need for this kind of feature)
Closes #73 (implementation planning)
Closes #75 (an old PR to do this pretty much)

## Review notes
This is the relevant implementation changing the default behavior to check unless --force-publish-chart has been passed.

https://github.com/jupyterhub/chartpress/pull/102/files#diff-b221c94b491bd2ffe6ebc5416067fd58b378f4eda722e75754468ed9f24aefefR587-R601