### PR TITLE
Major refactor for readability pre 1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ usage: chartpress [-h] [--push] [--force-push] [--publish-chart]
                   [--force-publish-chart] [--extra-message EXTRA_MESSAGE]
                   [--tag TAG | --long] [--image-prefix IMAGE_PREFIX] [--reset]
                   [--skip-build | --force-build] [--list-images] [--version]
-                  [--commit-range COMMIT_RANGE]
 
 Automate building and publishing helm charts and associated images. This is
 used as part of the JupyterHub and Binder projects.
@@ -128,13 +127,6 @@ optional arguments:
   --list-images         print list of images to stdout. Images will not be
                         built.
   --version             Print current chartpress version and exit.
-  --commit-range COMMIT_RANGE
-                        Deprecated: this flag will be ignored. The new logic
-                        to determine if an image needs to be rebuilt does not
-                        require this. It will find the time in git history
-                        where the image was last in need of a rebuild due to
-                        changes, and check if that build exists locally or
-                        remotely already.
 ```
 
 ## Configuration

--- a/chartpress.py
+++ b/chartpress.py
@@ -121,7 +121,7 @@ def _latest_commit_tagged_or_modifying_path(*paths, **kwargs):
     Get the latest of a) the latest tagged commit, or b) the latest commit
     modifying provided path.
     """
-    latest_commit_modifying_path = _get_latest_commit_modifying_path(**kwargs)
+    latest_commit_modifying_path = _get_latest_commit_modifying_path(*paths, **kwargs)
 
     latest_tag = _get_latest_tag(**kwargs)
     if not latest_tag:
@@ -234,7 +234,7 @@ def docker_client():
 
 
 @lru_cache()
-def image_needs_pushing(image):
+def _image_needs_pushing(image):
     """
     Returns a boolean whether an image needs pushing by checking if the image
     exists on the image registry.
@@ -287,7 +287,7 @@ def image_needs_building(image):
         return False
 
     # image may need building if it's not on the registry
-    return image_needs_pushing(image)
+    return _image_needs_pushing(image)
 
 
 def _get_identifier(tag, n_commits, commit, long):
@@ -430,7 +430,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, chart_v
             log(f"Skipping build for {image_spec}, it already exists")
 
         if push or force_push:
-            if force_push or image_needs_pushing(image_spec):
+            if force_push or _image_needs_pushing(image_spec):
                 check_call([
                     'docker', 'push', image_spec
                 ])

--- a/chartpress.py
+++ b/chartpress.py
@@ -186,19 +186,20 @@ def _get_image_dockerfile_path(name, options):
 
 def _get_all_image_paths(name, options):
     """
-    Returns the paths that when changed should trigger a rebuild of a chart's
-    image. This includes the Dockerfile itself and the context of the Dockerfile
-    during the build process.
+    Returns the unique paths that when changed should trigger a rebuild of a
+    chart's image. This includes the Dockerfile itself and the context of the
+    Dockerfile during the build process.
 
     The first element will always be the context path, the second always the
     Dockerfile path, and the optional others for extra paths.
     """
-    r = []
+    paths = []
+    paths.append("chartpress.yaml")
     if options.get("rebuildOnContextPathChanges", True):
-        r.append(_get_image_build_context_path(name, options))
-    r.append(_get_image_dockerfile_path(name, options))
-    r.extend(options.get("paths", []))
-    return r
+        paths.append(_get_image_build_context_path(name, options))
+    paths.append(_get_image_dockerfile_path(name, options))
+    paths.extend(options.get("paths", []))
+    return list(set(paths))
 
 
 def _get_all_chart_paths(options):
@@ -426,7 +427,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, force_b
     for name, options in images.items():
         # include chartpress.yaml in the image paths to inspect as
         # chartpress.yaml can contain build args influencing the image
-        all_image_paths = _get_all_image_paths(name, options) + ["chartpress.yaml"]
+        all_image_paths = _get_all_image_paths(name, options)
 
         # decide a tag string
         if tag is None:

--- a/chartpress.py
+++ b/chartpress.py
@@ -116,10 +116,10 @@ def _get_commit_from_tag(tag, **kwargs):
 
 
 @lru_cache()
-def _latest_commit_tagged_or_modifying_path(*paths, **kwargs):
+def _get_latest_commit_tagged_or_modifying_paths(*paths, **kwargs):
     """
     Get the latest of a) the latest tagged commit, or b) the latest commit
-    modifying provided path.
+    modifying any file in the the provided paths.
     """
     latest_commit_modifying_path = _get_latest_commit_modifying_path(*paths, **kwargs)
 
@@ -296,7 +296,7 @@ def _image_needs_building(image):
 
 
 def _get_identifier_from_paths(*paths, long=False):
-    latest_commit = _latest_commit_tagged_or_modifying_path(*paths, echo=False)
+    latest_commit = _get_latest_commit_tagged_or_modifying_paths(*paths, echo=False)
 
     try:
         git_describe = _check_output(
@@ -443,7 +443,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, force_b
                 build_args=_get_image_build_args(
                     options,
                     {
-                        'LAST_COMMIT': _latest_commit_tagged_or_modifying_path(*all_image_paths, echo=False),
+                        'LAST_COMMIT': _get_latest_commit_tagged_or_modifying_paths(*all_image_paths, echo=False),
                         'TAG': tag,
                     },
                 )

--- a/chartpress.py
+++ b/chartpress.py
@@ -184,7 +184,7 @@ def _get_image_dockerfile_path(name, options):
         return os.path.join(_get_image_build_context_path(name, options), "Dockerfile")
 
 
-def get_image_paths(name, options):
+def _get_all_image_paths(name, options):
     """
     Returns the paths that when changed should trigger a rebuild of a chart's
     image. This includes the Dockerfile itself and the context of the Dockerfile
@@ -387,7 +387,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, chart_v
         chart_version = _strip_identifiers_build_suffix(chart_version)
         # include chartpress.yaml itself as it can contain build args and
         # similar that influence the image that would be built
-        image_paths = get_image_paths(name, options) + ["chartpress.yaml"]
+        image_paths = _get_all_image_paths(name, options) + ["chartpress.yaml"]
         context_path = _get_image_build_context_path(name, options)
         dockerfile_path = _get_image_dockerfile_path(name, options)
         image_commit = _latest_commit_tagged_or_modifying_path(*image_paths, echo=False)
@@ -779,7 +779,7 @@ def main(args=None):
         chart_paths.extend(chart.get('paths', []))
         if 'images' in chart:
             for image_name, image_config in chart['images'].items():
-                chart_paths.extend(get_image_paths(image_name, image_config))
+                chart_paths.extend(_get_all_image_paths(image_name, image_config))
         chart_paths = list(set(chart_paths))
 
         chart_version = args.tag

--- a/chartpress.py
+++ b/chartpress.py
@@ -259,7 +259,7 @@ def _image_needs_pushing(image):
         return False
 
 @lru_cache()
-def image_needs_building(image):
+def _image_needs_building(image):
     """
     Returns a boolean whether an image needs building by checking if the image
     exists either locally or on the registry.
@@ -417,7 +417,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, chart_v
         if skip_build:
             continue
 
-        if force_build or image_needs_building(image_spec):
+        if force_build or _image_needs_building(image_spec):
             build_args = render_build_args(
                 options,
                 {

--- a/chartpress.py
+++ b/chartpress.py
@@ -143,7 +143,7 @@ def _latest_commit_tagged_or_modifying_path(*paths, **kwargs):
         return latest_commit_modifying_path
 
 
-def render_build_args(image_options, ns):
+def _get_image_build_args(image_options, ns):
     """
     Render buildArgs from chartpress.yaml that could be templates, using
     provided namespace that contains keys with dynamic values such as
@@ -423,7 +423,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, chart_v
             continue
 
         if force_build or _image_needs_building(image_spec):
-            build_args = render_build_args(
+            build_args = _get_image_build_args(
                 options,
                 {
                     'LAST_COMMIT': image_commit,

--- a/chartpress.py
+++ b/chartpress.py
@@ -381,7 +381,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, chart_v
         - long=False: 0.9.0-n004.hsdfg2345
         - long=True:  0.9.0-n004.hsdfg2345
     """
-    value_modifications = {}
+    values_file_modifications = {}
     for name, options in images.items():
         image_tag = tag
         chart_version = _strip_build_suffix_from_identifier(chart_version)
@@ -414,7 +414,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, chart_v
             values_path_list = [values_path_list]
 
         for values_path in values_path_list:
-            value_modifications[values_path] = {
+            values_file_modifications[values_path] = {
                 'repository': image_name,
                 'tag': SingleQuotedScalarString(image_tag),
             }
@@ -441,7 +441,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, chart_v
                 ])
             else:
                 _log(f"Skipping push for {image_spec}, already on registry")
-    return value_modifications
+    return values_file_modifications
 
 
 def _update_values_file_with_modifications(name, modifications):
@@ -796,7 +796,7 @@ def main(args=None):
 
         if 'images' in chart:
             image_prefix = args.image_prefix or chart.get('imagePrefix', '')
-            value_mods = build_images(
+            values_file_modifications = build_images(
                 prefix=image_prefix,
                 images=chart['images'],
                 tag=args.tag if not args.reset else chart.get('resetTag', 'set-by-chartpress'),
@@ -809,14 +809,14 @@ def main(args=None):
             )
             if args.list_images:
                 seen_images = set()
-                for key, image_dict in value_mods.items():
+                for key, image_dict in values_file_modifications.items():
                     image = "{repository}:{tag}".format(**image_dict)
                     if image not in seen_images:
                         print(image)
                         # record image, in case the same image occurs in multiple places
                         seen_images.add(image)
                 return
-            _update_values_file_with_modifications(chart['name'], value_mods)
+            _update_values_file_with_modifications(chart['name'], values_file_modifications)
 
         if args.publish_chart or args.force_publish_chart:
             publish_pages(

--- a/chartpress.py
+++ b/chartpress.py
@@ -749,11 +749,6 @@ def main(args=None):
         action='store_true',
         help='Print current chartpress version and exit.',
     )
-    argparser.add_argument(
-        '--commit-range',
-        action=ActionStoreDeprecated,
-        help='Deprecated: this flag will be ignored. The new logic to determine if an image needs to be rebuilt does not require this. It will find the time in git history where the image was last in need of a rebuild due to changes, and check if that build exists locally or remotely already.',
-    )
 
     args = argparser.parse_args(args)
 

--- a/chartpress.py
+++ b/chartpress.py
@@ -310,7 +310,7 @@ def _get_identifier_from_paths(*paths, long=False):
         # ref: https://git-scm.com/docs/git-describe#_examples
         sha = sha[1:]
 
-        return _get_identifier(latest_tag_in_branch, n_commits, sha, long)
+        return _get_identifier_from_parts(latest_tag_in_branch, n_commits, sha, long)
     except subprocess.CalledProcessError:
         # no tags on branch, so assume 0.0.1 and
         # calculate n_commits from latest_commit
@@ -321,10 +321,10 @@ def _get_identifier_from_paths(*paths, long=False):
             echo=False,
         ).decode('utf-8').strip()
 
-        return _get_identifier("0.0.1", n_commits, latest_commit, long)
+        return _get_identifier_from_parts("0.0.1", n_commits, latest_commit, long)
 
 
-def _get_identifier(tag, n_commits, commit, long):
+def _get_identifier_from_parts(tag, n_commits, commit, long):
     """
     Returns a chartpress formatted chart version or image tag (identifier) with
     a build suffix.

--- a/chartpress.py
+++ b/chartpress.py
@@ -802,9 +802,9 @@ def main(args=None):
         )
 
         if 'images' in chart:
-            image_prefix = args.image_prefix or chart.get('imagePrefix', '')
+            # build images
             values_file_modifications = build_images(
-                prefix=image_prefix,
+                prefix=args.image_prefix or chart.get('imagePrefix', ''),
                 images=chart['images'],
                 tag=args.tag if not args.reset else chart.get('resetTag', 'set-by-chartpress'),
                 push=args.push,
@@ -813,6 +813,8 @@ def main(args=None):
                 skip_build=args.skip_build or args.reset,
                 long=args.long,
             )
+
+            # list images
             if args.list_images:
                 seen_images = set()
                 for key, image_dict in values_file_modifications.items():
@@ -822,8 +824,11 @@ def main(args=None):
                         # record image, in case the same image occurs in multiple places
                         seen_images.add(image)
                 return
+
+            # update values.yaml
             _update_values_file_with_modifications(chart['name'], values_file_modifications)
 
+        # publish chart
         if args.publish_chart or args.force_publish_chart:
             publish_pages(
                 chart_name=chart['name'],

--- a/chartpress.py
+++ b/chartpress.py
@@ -444,14 +444,16 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, chart_v
     return value_modifications
 
 
-def build_values(name, values_mods):
-    """Update name/values.yaml with modifications"""
+def _update_values_file_with_modifications(name, modifications):
+    """
+    Update <name>/values.yaml file with a dictionary of modifications.
+    """
     values_file = os.path.join(name, 'values.yaml')
 
     with open(values_file) as f:
         values = yaml.load(f)
 
-    for key, value in values_mods.items():
+    for key, value in modifications.items():
         if not isinstance(value, dict) or set(value.keys()) != {'repository', 'tag'}:
             raise ValueError(f"I only understand image updates with 'repository', 'tag', not: {value!r}")
         parts = key.split('.')
@@ -814,7 +816,7 @@ def main(args=None):
                         # record image, in case the same image occurs in multiple places
                         seen_images.add(image)
                 return
-            build_values(chart['name'], value_mods)
+            _update_values_file_with_modifications(chart['name'], value_mods)
 
         if args.publish_chart or args.force_publish_chart:
             publish_pages(

--- a/chartpress.py
+++ b/chartpress.py
@@ -162,9 +162,9 @@ def _get_image_build_args(image_options, ns):
     return build_args
 
 
-def get_image_context_path(name, options):
+def _get_image_build_context_path(name, options):
     """
-    Return the image's contextPath configuration value or a default value based
+    Return the image's contextPath configuration value, or a default value based
     on the image name.
     """
     if options.get("contextPath"):
@@ -181,7 +181,7 @@ def get_image_dockerfile_path(name, options):
     if options.get("dockerfilePath"):
         return options["dockerfilePath"]
     else:
-        return os.path.join(get_image_context_path(name, options), "Dockerfile")
+        return os.path.join(_get_image_build_context_path(name, options), "Dockerfile")
 
 
 def get_image_paths(name, options):
@@ -195,7 +195,7 @@ def get_image_paths(name, options):
     """
     r = []
     if options.get("rebuildOnContextPathChanges", True):
-        r.append(get_image_context_path(name, options))
+        r.append(_get_image_build_context_path(name, options))
     r.append(get_image_dockerfile_path(name, options))
     r.extend(options.get("paths", []))
     return r
@@ -388,7 +388,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, chart_v
         # include chartpress.yaml itself as it can contain build args and
         # similar that influence the image that would be built
         image_paths = get_image_paths(name, options) + ["chartpress.yaml"]
-        context_path = get_image_context_path(name, options)
+        context_path = _get_image_build_context_path(name, options)
         dockerfile_path = get_image_dockerfile_path(name, options)
         image_commit = _latest_commit_tagged_or_modifying_path(*image_paths, echo=False)
         if image_tag is None:

--- a/chartpress.py
+++ b/chartpress.py
@@ -61,7 +61,7 @@ def _check_call(cmd, **kwargs):
 _check_output = partial(_run_cmd, subprocess.check_output)
 
 
-def git_remote(git_repo):
+def _get_git_remote_url(git_repo):
     """Return the URL for remote git repository.
 
     Depending on the system setup it returns ssh or https remote.
@@ -598,7 +598,7 @@ def publish_pages(chart_name, chart_version, chart_repo_github_path, chart_repo_
         _check_call(
             [
                 'git', 'clone', '--no-checkout',
-                git_remote(chart_repo_github_path),
+                _get_git_remote_url(chart_repo_github_path),
                 checkout_dir,
             ],
             # We don't echo the GITHUB_TOKEN, it is censored in run_call

--- a/chartpress.py
+++ b/chartpress.py
@@ -173,7 +173,7 @@ def _get_image_build_context_path(name, options):
         return os.path.join("images", name)
 
 
-def get_image_dockerfile_path(name, options):
+def _get_image_dockerfile_path(name, options):
     """
     Return the image dockerfilePath configuration value or a default value based
     on the contextPath.
@@ -196,7 +196,7 @@ def get_image_paths(name, options):
     r = []
     if options.get("rebuildOnContextPathChanges", True):
         r.append(_get_image_build_context_path(name, options))
-    r.append(get_image_dockerfile_path(name, options))
+    r.append(_get_image_dockerfile_path(name, options))
     r.extend(options.get("paths", []))
     return r
 
@@ -389,7 +389,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, chart_v
         # similar that influence the image that would be built
         image_paths = get_image_paths(name, options) + ["chartpress.yaml"]
         context_path = _get_image_build_context_path(name, options)
-        dockerfile_path = get_image_dockerfile_path(name, options)
+        dockerfile_path = _get_image_dockerfile_path(name, options)
         image_commit = _latest_commit_tagged_or_modifying_path(*image_paths, echo=False)
         if image_tag is None:
             n_commits = _check_output(

--- a/chartpress.py
+++ b/chartpress.py
@@ -42,7 +42,7 @@ def _log(message):
     print(message, file=sys.stderr)
 
 
-def run_cmd(call, cmd, *, echo=True, **kwargs):
+def _run_cmd(call, cmd, *, echo=True, **kwargs):
     """Run a command and echo it first with censoring of GITHUB_TOKEN."""
     if echo:
         cmd_string = " ".join(map(pipes.quote, cmd))
@@ -55,10 +55,10 @@ def run_cmd(call, cmd, *, echo=True, **kwargs):
 
 def check_call(cmd, **kwargs):
     kwargs.setdefault("stdout", sys.stderr.fileno())
-    return run_cmd(subprocess.check_call, cmd, **kwargs)
+    return _run_cmd(subprocess.check_call, cmd, **kwargs)
 
 
-check_output = partial(run_cmd, subprocess.check_output)
+check_output = partial(_run_cmd, subprocess.check_output)
 
 
 def git_remote(git_repo):

--- a/chartpress.py
+++ b/chartpress.py
@@ -34,7 +34,7 @@ yaml.preserve_quotes = True ## avoid mangling of quotes
 yaml.indent(mapping=2, offset=2, sequence=4)
 
 
-def log(message):
+def _log(message):
     """Print messages to stderr
 
     to avoid conflicts with piped output, e.g. `--list-images`
@@ -49,7 +49,7 @@ def run_cmd(call, cmd, *, echo=True, **kwargs):
         github_token = os.getenv(GITHUB_TOKEN_KEY)
         if github_token:
             cmd_string = cmd_string.replace(github_token, "CENSORED_GITHUB_TOKEN")
-        log("$> " + cmd_string)
+        _log("$> " + cmd_string)
     return call(cmd, **kwargs)
 
 
@@ -432,7 +432,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, chart_v
             )
             build_image(image_spec, context_path, dockerfile_path=dockerfile_path, build_args=build_args)
         else:
-            log(f"Skipping build for {image_spec}, it already exists")
+            _log(f"Skipping build for {image_spec}, it already exists")
 
         if push or force_push:
             if force_push or _image_needs_pushing(image_spec):
@@ -440,7 +440,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, chart_v
                     'docker', 'push', image_spec
                 ])
             else:
-                log(f"Skipping push for {image_spec}, already on registry")
+                _log(f"Skipping push for {image_spec}, already on registry")
     return value_modifications
 
 
@@ -470,7 +470,7 @@ def build_values(name, values_mods):
                 for repo_key in keys:
                     before = mod_obj.get(repo_key, None)
                     if before != value['repository']:
-                        log(f"Updating {values_file}: {key}.{repo_key}: {value}")
+                        _log(f"Updating {values_file}: {key}.{repo_key}: {value}")
                     mod_obj[repo_key] = value['repository']
             else:
                 possible_keys = ' or '.join(IMAGE_REPOSITORY_KEYS)
@@ -480,7 +480,7 @@ def build_values(name, values_mods):
 
             before = mod_obj.get('tag', None)
             if before != value['tag']:
-                log(f"Updating {values_file}: {key}.tag: {value}")
+                _log(f"Updating {values_file}: {key}.tag: {value}")
             mod_obj['tag'] = value['tag']
         elif isinstance(mod_obj, str):
             # scalar image string, not dict with separate repository, tag keys
@@ -490,7 +490,7 @@ def build_values(name, values_mods):
             except (KeyError, IndexError):
                 before = None
             if before != image:
-                log(f"Updating {values_file}: {key}: {image}")
+                _log(f"Updating {values_file}: {key}: {image}")
             parent[last_part] = image
         else:
             raise TypeError(
@@ -551,7 +551,7 @@ def build_chart(name, version=None, paths=None, long=False):
             version = _get_identifier(latest_tag_in_branch, n_commits, chart_commit, long)
 
     if chart['version'] != version:
-        log(f"Updating {chart_file}: version: {version}")
+        _log(f"Updating {chart_file}: version: {version}")
         chart['version'] = version
 
     with open(chart_file, 'w') as f:
@@ -619,9 +619,9 @@ def publish_pages(chart_name, chart_version, chart_repo_github_path, chart_repo_
 
         if any(c["version"] == chart_version for c in published_charts):
             if force:
-                log(f"Chart of version {chart_version} already exists, overwriting it.")
+                _log(f"Chart of version {chart_version} already exists, overwriting it.")
             else:
-                log(f"Skipping chart publishing of version {chart_version}, it is already published")
+                _log(f"Skipping chart publishing of version {chart_version}, it is already published")
                 return
 
     # package the latest version into a temporary directory
@@ -661,14 +661,14 @@ def publish_pages(chart_name, chart_version, chart_repo_github_path, chart_repo_
 class ActionStoreDeprecated(argparse.Action):
     """Used with argparse as a deprecation action."""
     def __call__(self, parser, namespace, values, option_string=None):
-        log(f"Warning: use of {'|'.join(self.option_strings)} is deprecated.")
+        _log(f"Warning: use of {'|'.join(self.option_strings)} is deprecated.")
         setattr(namespace, self.dest, values)
 
 
 class ActionAppendDeprecated(argparse.Action):
     """Used with argparse as a deprecation action."""
     def __call__(self, parser, namespace, values, option_string=None):
-        log(f"Warning: use of {'|'.join(self.option_strings)} is deprecated.")
+        _log(f"Warning: use of {'|'.join(self.option_strings)} is deprecated.")
         if not getattr(namespace, self.dest):
             setattr(namespace, self.dest, [])
         getattr(namespace, self.dest).append(values)

--- a/chartpress.py
+++ b/chartpress.py
@@ -172,6 +172,7 @@ def get_image_context_path(name, options):
     else:
         return os.path.join("images", name)
 
+
 def get_image_dockerfile_path(name, options):
     """
     Return the image dockerfilePath configuration value or a default value based
@@ -181,6 +182,7 @@ def get_image_dockerfile_path(name, options):
         return options["dockerfilePath"]
     else:
         return os.path.join(get_image_context_path(name, options), "Dockerfile")
+
 
 def get_image_paths(name, options):
     """
@@ -197,6 +199,7 @@ def get_image_paths(name, options):
     r.append(get_image_dockerfile_path(name, options))
     r.extend(options.get("paths", []))
     return r
+
 
 def build_image(image_spec, context_path, dockerfile_path=None, build_args=None):
     """Build an image
@@ -227,8 +230,9 @@ def build_image(image_spec, context_path, dockerfile_path=None, build_args=None)
         cmd += ['--build-arg', f'{k}={v}']
     check_call(cmd)
 
+
 @lru_cache()
-def docker_client():
+def _get_docker_client():
     """Cached getter for docker client"""
     return docker.from_env()
 
@@ -249,7 +253,7 @@ def _image_needs_pushing(image):
         - index.docker.io/library/ubuntu:latest
         - eu.gcr.io/my-gcp-project/my-image:0.1.0
     """
-    d = docker_client()
+    d = _get_docker_client()
     try:
         d.images.get_registry_data(image)
     except docker.errors.APIError:
@@ -257,6 +261,7 @@ def _image_needs_pushing(image):
         return True
     else:
         return False
+
 
 @lru_cache()
 def _image_needs_building(image):
@@ -274,7 +279,7 @@ def _image_needs_building(image):
         - index.docker.io/library/ubuntu:latest
         - eu.gcr.io/my-gcp-project/my-image:0.1.0
     """
-    d = docker_client()
+    d = _get_docker_client()
 
     # first, check for locally built image
     try:

--- a/chartpress.py
+++ b/chartpress.py
@@ -325,7 +325,7 @@ def _get_identifier(tag, n_commits, commit, long):
         return f"{tag}"
 
 
-def _strip_identifiers_build_suffix(identifier):
+def _strip_build_suffix_from_identifier(identifier):
     """
     Return a stripped chart version or image tag (identifier) without its build
     suffix (.n005.hasdf1234), leaving it to represent a Semver 2 release or
@@ -384,7 +384,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, chart_v
     value_modifications = {}
     for name, options in images.items():
         image_tag = tag
-        chart_version = _strip_identifiers_build_suffix(chart_version)
+        chart_version = _strip_build_suffix_from_identifier(chart_version)
         # include chartpress.yaml itself as it can contain build args and
         # similar that influence the image that would be built
         image_paths = _get_all_image_paths(name, options) + ["chartpress.yaml"]

--- a/chartpress.py
+++ b/chartpress.py
@@ -58,7 +58,7 @@ def _check_call(cmd, **kwargs):
     return _run_cmd(subprocess.check_call, cmd, **kwargs)
 
 
-check_output = partial(_run_cmd, subprocess.check_output)
+_check_output = partial(_run_cmd, subprocess.check_output)
 
 
 def git_remote(git_repo):
@@ -80,7 +80,7 @@ def git_remote(git_repo):
 
 def _get_latest_commit_modifying_path(*paths, **kwargs):
     """Get the latest commit modifying the given path or return None."""
-    return check_output(
+    return _check_output(
         [
             'git', 'log',
             '--max-count=1',
@@ -97,7 +97,7 @@ def _get_latest_tag(**kwargs):
     try:
         # If the git command output is my-tag-14-g0aed65e,
         # then the return value will become my-tag.
-        return check_output(
+        return _check_output(
             ['git', 'describe', '--tags', '--long'],
             **kwargs,
         ).decode('utf-8').strip().rsplit("-", maxsplit=2)[0]
@@ -107,7 +107,7 @@ def _get_latest_tag(**kwargs):
 
 def _get_commit_from_tag(tag, **kwargs):
     """Return the abbreviated commit hash for the tag."""
-    return check_output(
+    return _check_output(
         [
             'git', 'rev-list', '--abbrev-commit', '-n', '1', tag,
         ],
@@ -392,7 +392,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, chart_v
         dockerfile_path = get_image_dockerfile_path(name, options)
         image_commit = _latest_commit_tagged_or_modifying_path(*image_paths, echo=False)
         if image_tag is None:
-            n_commits = check_output(
+            n_commits = _check_output(
                 [
                     'git', 'rev-list', '--count',
                     # Note that the 0.0.1 chart_version may not exist as it was a
@@ -526,7 +526,7 @@ def build_chart(name, version=None, paths=None, long=False):
         chart_commit = _latest_commit_tagged_or_modifying_path(*paths, echo=False)
 
         try:
-            git_describe = check_output(
+            git_describe = _check_output(
                 [
                     'git', 'describe', '--tags', '--long', chart_commit
                 ],
@@ -541,7 +541,7 @@ def build_chart(name, version=None, paths=None, long=False):
             # no tags on branch: fallback to the SemVer 2 compliant version
             # 0.0.1-<n_commits>.<chart_commit>
             latest_tag_in_branch = "0.0.1"
-            n_commits = check_output(
+            n_commits = _check_output(
                 [
                     'git', 'rev-list', '--count', chart_commit
                 ],

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,7 +2,7 @@ from chartpress import GITHUB_TOKEN_KEY
 
 from chartpress import _get_git_remote_url
 from chartpress import _image_needs_pushing
-from chartpress import _latest_commit_tagged_or_modifying_path
+from chartpress import _get_latest_commit_tagged_or_modifying_paths
 from chartpress import _get_image_build_args
 from chartpress import _check_call
 from chartpress import _strip_build_suffix_from_identifier
@@ -43,7 +43,7 @@ def test__image_needs_pushing():
     assert _image_needs_pushing("jupyterhub/image-not-to-be-found:latest")
     assert not _image_needs_pushing("jupyterhub/k8s-hub:0.8.2")
 
-def test__latest_commit_tagged_or_modifying_path(git_repo):
+def test__get_latest_commit_tagged_or_modifying_paths(git_repo):
     open('tag-mod.txt', "w").close()
     git_repo.index.add("tag-mod.txt")
     tag_commit = git_repo.index.commit("tag commit")
@@ -53,9 +53,9 @@ def test__latest_commit_tagged_or_modifying_path(git_repo):
     git_repo.index.add("post-tag-mod.txt")
     post_tag_commit = git_repo.index.commit("post tag commit")
 
-    assert _latest_commit_tagged_or_modifying_path("chartpress.yaml")  == tag_commit.hexsha[:7]
-    assert _latest_commit_tagged_or_modifying_path("tag-mod.txt")      == tag_commit.hexsha[:7]
-    assert _latest_commit_tagged_or_modifying_path("post-tag-mod.txt") == post_tag_commit.hexsha[:7]
+    assert _get_latest_commit_tagged_or_modifying_paths("chartpress.yaml")  == tag_commit.hexsha[:7]
+    assert _get_latest_commit_tagged_or_modifying_paths("tag-mod.txt")      == tag_commit.hexsha[:7]
+    assert _get_latest_commit_tagged_or_modifying_paths("post-tag-mod.txt") == post_tag_commit.hexsha[:7]
 
 def test__get_image_build_args(git_repo):
     with open('chartpress.yaml') as f:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,7 +2,7 @@ from chartpress import GITHUB_TOKEN_KEY
 
 from chartpress import git_remote
 from chartpress import image_needs_pushing
-from chartpress import latest_tag_or_mod_commit
+from chartpress import _latest_commit_tagged_or_modifying_path
 from chartpress import render_build_args
 from chartpress import check_call
 from chartpress import _strip_identifiers_build_suffix
@@ -43,7 +43,7 @@ def test_image_needs_pushing():
     assert image_needs_pushing("jupyterhub/image-not-to-be-found:latest")
     assert not image_needs_pushing("jupyterhub/k8s-hub:0.8.2")
 
-def test_latest_tag_or_mod_commit(git_repo):
+def test__latest_commit_tagged_or_modifying_path(git_repo):
     open('tag-mod.txt', "w").close()
     git_repo.index.add("tag-mod.txt")
     tag_commit = git_repo.index.commit("tag commit")
@@ -53,9 +53,9 @@ def test_latest_tag_or_mod_commit(git_repo):
     git_repo.index.add("post-tag-mod.txt")
     post_tag_commit = git_repo.index.commit("post tag commit")
 
-    assert latest_tag_or_mod_commit("chartpress.yaml")  == tag_commit.hexsha[:7]
-    assert latest_tag_or_mod_commit("tag-mod.txt")      == tag_commit.hexsha[:7]
-    assert latest_tag_or_mod_commit("post-tag-mod.txt") == post_tag_commit.hexsha[:7]
+    assert _latest_commit_tagged_or_modifying_path("chartpress.yaml")  == tag_commit.hexsha[:7]
+    assert _latest_commit_tagged_or_modifying_path("tag-mod.txt")      == tag_commit.hexsha[:7]
+    assert _latest_commit_tagged_or_modifying_path("post-tag-mod.txt") == post_tag_commit.hexsha[:7]
 
 def test_render_build_args(git_repo):
     with open('chartpress.yaml') as f:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,7 +3,7 @@ from chartpress import GITHUB_TOKEN_KEY
 from chartpress import _get_git_remote_url
 from chartpress import _image_needs_pushing
 from chartpress import _latest_commit_tagged_or_modifying_path
-from chartpress import render_build_args
+from chartpress import _get_image_build_args
 from chartpress import _check_call
 from chartpress import _strip_identifiers_build_suffix
 from chartpress import _get_identifier
@@ -57,12 +57,12 @@ def test__latest_commit_tagged_or_modifying_path(git_repo):
     assert _latest_commit_tagged_or_modifying_path("tag-mod.txt")      == tag_commit.hexsha[:7]
     assert _latest_commit_tagged_or_modifying_path("post-tag-mod.txt") == post_tag_commit.hexsha[:7]
 
-def test_render_build_args(git_repo):
+def test__get_image_build_args(git_repo):
     with open('chartpress.yaml') as f:
         config = yaml.load(f)
     for chart in config["charts"]:
         for name, options in chart["images"].items():
-            build_args = render_build_args(
+            build_args = _get_image_build_args(
                 options,
                 {
                     'LAST_COMMIT': "sha",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,6 @@
 from chartpress import GITHUB_TOKEN_KEY
 
-from chartpress import git_remote
+from chartpress import _get_git_remote_url
 from chartpress import _image_needs_pushing
 from chartpress import _latest_commit_tagged_or_modifying_path
 from chartpress import render_build_args
@@ -26,12 +26,12 @@ def test__get_identifier():
     assert _get_identifier(tag="0.1.2-alpha.1", n_commits="0", commit="asdf1234", long=False) == "0.1.2-alpha.1"
     assert _get_identifier(tag="0.1.2-alpha.1", n_commits="5", commit="asdf1234", long=False) == "0.1.2-alpha.1.n005.hasdf1234"
 
-def test_git_remote(monkeypatch):
+def test__get_git_remote_url(monkeypatch):
     monkeypatch.setenv(GITHUB_TOKEN_KEY, "test-github-token")
-    assert git_remote("jupyterhub/helm-chart") == "https://test-github-token@github.com/jupyterhub/helm-chart"
+    assert _get_git_remote_url("jupyterhub/helm-chart") == "https://test-github-token@github.com/jupyterhub/helm-chart"
 
     monkeypatch.delenv(GITHUB_TOKEN_KEY)
-    assert git_remote("jupyterhub/helm-chart") == "git@github.com:jupyterhub/helm-chart"
+    assert _get_git_remote_url("jupyterhub/helm-chart") == "git@github.com:jupyterhub/helm-chart"
 
 def test_git_token_censoring(monkeypatch, capfd):
     monkeypatch.setenv(GITHUB_TOKEN_KEY, "secret-token-not-to-be-exposed-in-logs")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,7 +1,7 @@
 from chartpress import GITHUB_TOKEN_KEY
 
 from chartpress import git_remote
-from chartpress import image_needs_pushing
+from chartpress import _image_needs_pushing
 from chartpress import _latest_commit_tagged_or_modifying_path
 from chartpress import render_build_args
 from chartpress import check_call
@@ -39,9 +39,9 @@ def test_git_token_censoring(monkeypatch, capfd):
     _, err = capfd.readouterr()
     assert "CENSORED_GITHUB_TOKEN" in err
 
-def test_image_needs_pushing():
-    assert image_needs_pushing("jupyterhub/image-not-to-be-found:latest")
-    assert not image_needs_pushing("jupyterhub/k8s-hub:0.8.2")
+def test__image_needs_pushing():
+    assert _image_needs_pushing("jupyterhub/image-not-to-be-found:latest")
+    assert not _image_needs_pushing("jupyterhub/k8s-hub:0.8.2")
 
 def test__latest_commit_tagged_or_modifying_path(git_repo):
     open('tag-mod.txt', "w").close()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -4,7 +4,7 @@ from chartpress import git_remote
 from chartpress import _image_needs_pushing
 from chartpress import _latest_commit_tagged_or_modifying_path
 from chartpress import render_build_args
-from chartpress import check_call
+from chartpress import _check_call
 from chartpress import _strip_identifiers_build_suffix
 from chartpress import _get_identifier
 
@@ -35,7 +35,7 @@ def test_git_remote(monkeypatch):
 
 def test_git_token_censoring(monkeypatch, capfd):
     monkeypatch.setenv(GITHUB_TOKEN_KEY, "secret-token-not-to-be-exposed-in-logs")
-    check_call(["echo", "Non failing dummy command with secret-token-not-to-be-exposed-in-logs"])
+    _check_call(["echo", "Non failing dummy command with secret-token-not-to-be-exposed-in-logs"])
     _, err = capfd.readouterr()
     assert "CENSORED_GITHUB_TOKEN" in err
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,7 +6,7 @@ from chartpress import _latest_commit_tagged_or_modifying_path
 from chartpress import _get_image_build_args
 from chartpress import _check_call
 from chartpress import _strip_build_suffix_from_identifier
-from chartpress import _get_identifier
+from chartpress import _get_identifier_from_parts
 
 from ruamel.yaml import YAML
 # use safe roundtrip yaml loader
@@ -18,13 +18,13 @@ def test__strip_build_suffix_from_identifier():
     assert _strip_build_suffix_from_identifier(identifier="0.1.2-n005.hasdf1234") == "0.1.2"
     assert _strip_build_suffix_from_identifier(identifier="0.1.2-alpha.1.n005.hasdf1234") == "0.1.2-alpha.1"
 
-def test__get_identifier():
-    assert _get_identifier(tag="0.1.2",         n_commits="0", commit="asdf123",  long=True)  == "0.1.2-n000.hasdf123"
-    assert _get_identifier(tag="0.1.2",         n_commits="0", commit="asdf123",  long=False) == "0.1.2"
-    assert _get_identifier(tag="0.1.2",         n_commits="5", commit="asdf123",  long=False) == "0.1.2-n005.hasdf123"
-    assert _get_identifier(tag="0.1.2-alpha.1", n_commits="0", commit="asdf1234", long=True)  == "0.1.2-alpha.1.n000.hasdf1234"
-    assert _get_identifier(tag="0.1.2-alpha.1", n_commits="0", commit="asdf1234", long=False) == "0.1.2-alpha.1"
-    assert _get_identifier(tag="0.1.2-alpha.1", n_commits="5", commit="asdf1234", long=False) == "0.1.2-alpha.1.n005.hasdf1234"
+def test__get_identifier_from_parts():
+    assert _get_identifier_from_parts(tag="0.1.2",         n_commits="0", commit="asdf123",  long=True)  == "0.1.2-n000.hasdf123"
+    assert _get_identifier_from_parts(tag="0.1.2",         n_commits="0", commit="asdf123",  long=False) == "0.1.2"
+    assert _get_identifier_from_parts(tag="0.1.2",         n_commits="5", commit="asdf123",  long=False) == "0.1.2-n005.hasdf123"
+    assert _get_identifier_from_parts(tag="0.1.2-alpha.1", n_commits="0", commit="asdf1234", long=True)  == "0.1.2-alpha.1.n000.hasdf1234"
+    assert _get_identifier_from_parts(tag="0.1.2-alpha.1", n_commits="0", commit="asdf1234", long=False) == "0.1.2-alpha.1"
+    assert _get_identifier_from_parts(tag="0.1.2-alpha.1", n_commits="5", commit="asdf1234", long=False) == "0.1.2-alpha.1.n005.hasdf1234"
 
 def test__get_git_remote_url(monkeypatch):
     monkeypatch.setenv(GITHUB_TOKEN_KEY, "test-github-token")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,7 +5,7 @@ from chartpress import _image_needs_pushing
 from chartpress import _latest_commit_tagged_or_modifying_path
 from chartpress import _get_image_build_args
 from chartpress import _check_call
-from chartpress import _strip_identifiers_build_suffix
+from chartpress import _strip_build_suffix_from_identifier
 from chartpress import _get_identifier
 
 from ruamel.yaml import YAML
@@ -14,9 +14,9 @@ yaml = YAML(typ='rt')
 yaml.preserve_quotes = True ## avoid mangling of quotes
 yaml.indent(mapping=2, offset=2, sequence=4)
 
-def test__strip_identifiers_build_suffix():
-    assert _strip_identifiers_build_suffix(identifier="0.1.2-n005.hasdf1234") == "0.1.2"
-    assert _strip_identifiers_build_suffix(identifier="0.1.2-alpha.1.n005.hasdf1234") == "0.1.2-alpha.1"
+def test__strip_build_suffix_from_identifier():
+    assert _strip_build_suffix_from_identifier(identifier="0.1.2-n005.hasdf1234") == "0.1.2"
+    assert _strip_build_suffix_from_identifier(identifier="0.1.2-alpha.1.n005.hasdf1234") == "0.1.2-alpha.1"
 
 def test__get_identifier():
     assert _get_identifier(tag="0.1.2",         n_commits="0", commit="asdf123",  long=True)  == "0.1.2-n000.hasdf123"

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -280,7 +280,7 @@ def _capture_output(args, capfd, expect_output=False):
     """
     # clear cache of in memory cached functions
     # this allows us to better mimic the chartpress CLI behavior
-    chartpress.image_needs_building.cache_clear()
+    chartpress._image_needs_building.cache_clear()
     chartpress._image_needs_pushing.cache_clear()
     chartpress._latest_commit_tagged_or_modifying_path.cache_clear()
 

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -282,7 +282,7 @@ def _capture_output(args, capfd, expect_output=False):
     # this allows us to better mimic the chartpress CLI behavior
     chartpress._image_needs_building.cache_clear()
     chartpress._image_needs_pushing.cache_clear()
-    chartpress._latest_commit_tagged_or_modifying_path.cache_clear()
+    chartpress._get_latest_commit_tagged_or_modifying_paths.cache_clear()
 
     # first flush past captured output, then run chartpress, and finally read
     # and save all output that came of it

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -282,7 +282,7 @@ def _capture_output(args, capfd, expect_output=False):
     # this allows us to better mimic the chartpress CLI behavior
     chartpress.image_needs_building.cache_clear()
     chartpress.image_needs_pushing.cache_clear()
-    chartpress.latest_tag_or_mod_commit.cache_clear()
+    chartpress._latest_commit_tagged_or_modifying_path.cache_clear()
 
     # first flush past captured output, then run chartpress, and finally read
     # and save all output that came of it

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -281,7 +281,7 @@ def _capture_output(args, capfd, expect_output=False):
     # clear cache of in memory cached functions
     # this allows us to better mimic the chartpress CLI behavior
     chartpress.image_needs_building.cache_clear()
-    chartpress.image_needs_pushing.cache_clear()
+    chartpress._image_needs_pushing.cache_clear()
     chartpress._latest_commit_tagged_or_modifying_path.cache_clear()
 
     # first flush past captured output, then run chartpress, and finally read


### PR DESCRIPTION
## Background
This PR stems from needing to make a change that was complicated to make without some refactoring, but I decided to a more proper refactoring of the chartpress.py file while I was at it.

## Goal
- __Reduce risk of future errors__
  By making the code more readable and with less complicated parts, we make it less prone to future errors.
- __Communicate change management intent with prefix \___
  By adding a prefix `_` to certain functions, I think we communicate that these functions should not be assumed to retain their function signature etc between version updates.
- __Improve code comprehension__
  With improved code comprehension others can have an easier time contributing with future maintenance etc.

## Changes
- __Updated function/variable names__
  Function names and variable names have been updated to be easier to understand (Thanks @willingc for pointing out the value of readability in a tweet a while back!)
- __Broke apart complicated functions__
  I broke apart complicated complicated functions to parts that could be named well and therefore help us better read the code as well as avoid repeating logic.
- __Deprecated flag removed__
  I removed the since long deprecated flag `--commit-range` which had stopped doing anything a while back even before it was deprecated.

## Review considerations
This PR is breaking for anyone using chartpress as a python library, but is not meant to break for anyone else. I look to merge this soon