### PR TITLE
Strip v prefixes for Chart.yaml versions for Helm3 compliancy"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,20 @@ information.
 1. `tag`: If not directly set by `--tag`, it will be inferred from most recent
    commit that is tagged in the _current branch_, or be set to 0.0.1 if no
    commit is tagged.
-   1. If the `--tag` flag starts with a `v`, it will be removed when setting the
-      Chart.yaml version specifically. An error will be raised if it still isn't
-      a valid SemVer2 version because Helm 3 requires it.
+   1. If the `tag` has a leading `v` but is otherwise a valid
+      [SemVer2](https://semver.org) version, it will be stripped from Chart.yaml
+      before its set as Helm 3 requires Helm chart versions to be SemVer2
+      compliant.
 1. The latest commit modifying content in a _relevant path_ since `tag`.
    1. `n`: The latest commit's distance to the tagged commit, described as 3 or
       more numbers, prefixed with n.
-   1. `h`: The latest commit's abbreviated SHA hash, which is typically 7 or a
-      few more characters, prefixed with h.
+   1. `h`: The latest commit's abbreviated hash. which is often 7-8 characters,
+      prefixed with h.
 1. If `tag` (like `0.10.0` or `0.10.0-beta.1`) contains a `-`, a `tag.n.h`
-   format will be used instead of a `tag-n.h` format.
-1. If `tag` (like `v1.0.0`) is prefixed with a `v`, it will be stripped.
+   format will be used instead of a `tag-n.h` format to be SemVer 2 compliant.
 1. If `--long` is specified or not. If `--long` is specified, tagged commits
-   will be written out with the `n.h` part appended to it.
+   will be written out with the `n.h` part appended to it, looking something
+   like `n000.gabcd123`
 
 ### Examples chart versions and image tags
 

--- a/README.md
+++ b/README.md
@@ -25,21 +25,22 @@ Chartpress can do the following with the help of some configuration.
 Chartpress will infer chart versions and image tags using a few key pieces of
 information.
 
-1. `tag`: The latest commit that is tagged on the current branch, or 0.0.1 if no
-   tag was found.
-2. The latest commit that influenced anything on a path within the git
-   repository that matters to the chart version or image tag. The paths that
-   matters is determined using the image build contexts and additional specified
-   paths.
-   1. `n`: The latest commits commit distance count since the tag, described as
-      3 or more numbers, prefixed with n.
-   2. `h`: The latest commits abbreviated SHA hash, which is typically 7
-      characters, prefixed with h.
-3. If `--long` is specified or not. When it is specified tagged commits will be
-   written out with `n000.h<hash>` appended to it.
-4. If `tag` contains a `-`, `tag.n.h` will be used, and if not, `tag-n.h` will
-   be used. There should be exactly one `-` in the final version specification
-   to become a valid SemVer2 version.
+1. `tag`: If not directly set by `--tag`, it will be inferred from most recent
+   commit that is tagged in the _current branch_, or be set to 0.0.1 if no
+   commit is tagged.
+   1. If the `--tag` flag starts with a `v`, it will be removed when setting the
+      Chart.yaml version specifically. An error will be raised if it still isn't
+      a valid SemVer2 version because Helm 3 requires it.
+1. The latest commit modifying content in a _relevant path_ since `tag`.
+   1. `n`: The latest commit's distance to the tagged commit, described as 3 or
+      more numbers, prefixed with n.
+   1. `h`: The latest commit's abbreviated SHA hash, which is typically 7 or a
+      few more characters, prefixed with h.
+1. If `tag` (like `0.10.0` or `0.10.0-beta.1`) contains a `-`, a `tag.n.h`
+   format will be used instead of a `tag-n.h` format.
+1. If `tag` (like `v1.0.0`) is prefixed with a `v`, it will be stripped.
+1. If `--long` is specified or not. If `--long` is specified, tagged commits
+   will be written out with the `n.h` part appended to it.
 
 ### Examples chart versions and image tags
 

--- a/chartpress.py
+++ b/chartpress.py
@@ -76,7 +76,7 @@ def _fix_chart_version(version):
         _log('Stripped a "v" from the chart version to become SemVer 2 compliant as required by Helm 3.')
         return version[1:]
 
-    raise ValueError(f'The version in Chart.yaml "{version}" isn't SemVer2 compliant as required by Helm 3!')
+    raise ValueError(f"The version in Chart.yaml '{version}' isn't SemVer2 compliant as required by Helm 3!")
 
 
 def _get_git_remote_url(git_repo):

--- a/chartpress.py
+++ b/chartpress.py
@@ -76,7 +76,7 @@ def _fix_chart_version(version):
         _log('Stripped a "v" from the chart version to become SemVer 2 compliant as required by Helm 3.')
         return version[1:]
 
-    raise ValueError(f'The Chart.yaml "{version}" required by Helm 3 to be SemVer2 compliant!')
+    raise ValueError(f'The version in Chart.yaml "{version}" isn't SemVer2 compliant as required by Helm 3!')
 
 
 def _get_git_remote_url(git_repo):

--- a/tests/test_helm_chart/chartpress_alternative.yaml
+++ b/tests/test_helm_chart/chartpress_alternative.yaml
@@ -2,5 +2,6 @@ charts:
   - name: testchart
     images:
       testimage:
-        imageName: test-image-name-configuration
+        imageName: testimage
         contextPath: image
+        valuesPath: image

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -267,10 +267,13 @@ def test_chartpress_run_alternative(git_repo_alternative, capfd):
     """
     r = git_repo_alternative
     sha = r.heads.master.commit.hexsha[:7]
-    tag = f"0.0.1-n002.h{sha}"
 
-    out = _capture_output([], capfd)
-    assert f"Successfully tagged test-image-name-configuration:{tag}" in out
+    # verify usage of --tag with a prefix v
+    tag = f"v1.0.0"
+
+    out = _capture_output(["--skip-build", "--tag", tag], capfd)
+    assert f"Updating testchart/Chart.yaml: version: {tag[1:]}" in out
+    assert f"Updating testchart/values.yaml: image: testimage:{tag}" in out
 
 
 def _capture_output(args, capfd, expect_output=False):

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -292,15 +292,4 @@ def _capture_output(args, capfd, expect_output=False):
     if not expect_output:
         assert out == ""
 
-    # since the output was captured, print it back out again for debugging
-    # purposes if a test fails for example
-    header = f'--- chartpress {" ".join(args)} ---'
-    footer = "-" * len(header)
-    print()
-    print(header)
-    print("out:")
-    print(out)
-    print("err:")
-    print(err, file=sys.stderr)
-    print(footer)
     return err


### PR DESCRIPTION
Note that this PR contain the commits of #105 as well, which should be merged first I think.

Closes #88 by stripping Chart.yaml version and notifying user about doing that, and also failing loudly if Chart.yaml still is invalid SemVer2 after that small fix attempt.
Closes #89 by updating the readme.