### PR TITLE
fix: compute tag per image

### DIFF
--- a/chartpress.py
+++ b/chartpress.py
@@ -449,7 +449,9 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, force_b
 
         # decide a tag string
         if tag is None:
-            tag = _get_identifier_from_paths(*all_image_paths, long=long)
+            image_tag = _get_identifier_from_paths(*all_image_paths, long=long)
+        else:
+            image_tag = tag
 
         image_name = options.get('imageName', prefix + name)
 
@@ -460,13 +462,13 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, force_b
         for values_path in values_path_list:
             values_file_modifications[values_path] = {
                 'repository': image_name,
-                'tag': SingleQuotedScalarString(tag),
+                'tag': SingleQuotedScalarString(image_tag),
             }
 
         if skip_build:
             continue
 
-        image_spec = f'{image_name}:{tag}'
+        image_spec = f'{image_name}:{image_tag}'
 
         # build image
         if force_build or _image_needs_building(image_spec):
@@ -478,7 +480,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, force_b
                     options,
                     {
                         'LAST_COMMIT': _get_latest_commit_tagged_or_modifying_paths(*all_image_paths, echo=False),
-                        'TAG': tag,
+                        'TAG': image_tag,
                     },
                 )
             )


### PR DESCRIPTION
I was trying to use `chartpress` to build binderhub with some (committed) changes to the builder, which I expected to trigger the building of a new `binderhub` image, but it did not. 

So I debugged `chartpress` and noticed that the `build_images` method would assign a value to `tag` using the first image in `images`. As this was the `cleaner` image, my builder changes were not included and as a result an older commit was assigned to `tag`. That same tag was then also used for the `binderhub` image and no new image built (as it already existed). 

In `jypterhub/binderhub` with a (committed) change to `builder.py`:

Before this PR:
```
$ chartpress
Updating binderhub/Chart.yaml: version: 0.2.0-n433.h38cd307
Skipping build for jupyterhub/k8s-image-cleaner:0.2.0-n415.hac2a96f, it already exists
Skipping build for jupyterhub/k8s-binderhub:0.2.0-n415.hac2a96f, it already exists
Updating binderhub/values.yaml: imageCleaner.image.tag: {'repository': 'jupyterhub/k8s-image-cleaner', 'tag': '0.2.0-n415.hac2a96f'}
Updating binderhub/values.yaml: image.tag: {'repository': 'jupyterhub/k8s-binderhub', 'tag': '0.2.0-n415.hac2a96f'}
```

Note that no image was built.

With this PR:
```
$ chartpress
Updating binderhub/Chart.yaml: version: 0.2.0-n433.h38cd307
Skipping build for jupyterhub/k8s-image-cleaner:0.2.0-n415.hac2a96f, it already exists
$> docker build -t jupyterhub/k8s-binderhub:0.2.0-n433.h38cd307 .. -f images/binderhub/Dockerfile
Sending build context to Docker daemon  9.695MB
Step 1/21 : ARG DIST=buster
Step 2/21 : FROM python:3.8-$DIST as build-stage
...
```

I.e., with this PR, chartpress builds a new binderhub image even if there's only been code changes that only affect the binderhub image.