### PR TITLE
allow standard `--no-build` prefix for disabling builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ hub and `--publish-chart` to publish the chart and index to gh-pages.
 usage: chartpress [-h] [--push] [--force-push] [--publish-chart]
                   [--force-publish-chart] [--extra-message EXTRA_MESSAGE]
                   [--tag TAG | --long] [--image-prefix IMAGE_PREFIX] [--reset]
-                  [--skip-build | --force-build] [--list-images] [--version]
+                  [--no-build | --force-build] [--list-images] [--version]
 
 Automate building and publishing helm charts and associated images. This is
 used as part of the JupyterHub and Binder projects.
@@ -123,7 +123,8 @@ optional arguments:
                         field and values.yaml's image tags. What it resets to
                         can be configured in chartpress.yaml with the resetTag
                         and resetVersion configurations.
-  --skip-build          Skip the image build step.
+  --no-build, --skip-build
+                        Skip the image build step.
   --force-build         Enforce the image build step, regardless of if the
                         image already is available either locally or remotely.
   --list-images         print list of images to stdout. Images will not be

--- a/chartpress.py
+++ b/chartpress.py
@@ -776,9 +776,10 @@ def main(args=None):
     )
     skip_or_force_build_group = argparser.add_mutually_exclusive_group()
     skip_or_force_build_group.add_argument(
-        '--skip-build',
-        action='store_true',
-        help='Skip the image build step.',
+        "--no-build",
+        "--skip-build",
+        action="store_true",
+        help="Skip the image build step.",
     )
     skip_or_force_build_group.add_argument(
         '--force-build',
@@ -807,7 +808,8 @@ def main(args=None):
         return
 
     if args.list_images:
-        args.skip_build = True
+        args.no_build = True
+
 
     with open('chartpress.yaml') as f:
         config = yaml.load(f)
@@ -845,7 +847,7 @@ def main(args=None):
                 push=args.push,
                 force_push=args.force_push,
                 force_build=args.force_build,
-                skip_build=args.skip_build or args.reset,
+                skip_build=args.no_build or args.reset,
                 long=args.long,
             )
 


### PR DESCRIPTION
`--no-$feature` is a standard format for disabling something on a CLI, so allow this form in addition to the existing `--skip-build`.

I've typed `chartpress --no-build` *so many times* at this point, I thought I might as well make it work :)