### PR TITLE
fix: preserve quote formatting for image tags also

### DIFF
--- a/chartpress.py
+++ b/chartpress.py
@@ -18,7 +18,6 @@ from tempfile import TemporaryDirectory
 
 import docker
 from ruamel.yaml import YAML
-from ruamel.yaml.scalarstring import SingleQuotedScalarString
 
 __version__ = '1.0.4.dev'
 
@@ -28,9 +27,10 @@ GITHUB_TOKEN_KEY = 'GITHUB_TOKEN'
 # name of possible repository keys used in image value
 IMAGE_REPOSITORY_KEYS = {'name', 'repository'}
 
-# use safe roundtrip yaml loader
+# use safe roundtrip yaml loader capable or preserving usage of no/single/double
+# quotes for a string for example
 yaml = YAML(typ='rt')
-yaml.preserve_quotes = True ## avoid mangling of quotes
+yaml.preserve_quotes = True
 yaml.indent(mapping=2, offset=2, sequence=4)
 
 
@@ -473,7 +473,7 @@ def build_images(prefix, images, tag=None, push=False, force_push=False, force_b
         for values_path in values_path_list:
             values_file_modifications[values_path] = {
                 'repository': image_name,
-                'tag': SingleQuotedScalarString(image_tag),
+                'tag': image_tag,
             }
 
         if skip_build:

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     keywords=['helm', 'kubernetes'],
     python_requires=">=3.6",
     install_requires=[
-        'ruamel.yaml>=0.15',
+        'ruamel.yaml>=0.15.44',
         'docker>=3.2.0',
     ],
     classifiers=[


### PR DESCRIPTION
This PR in practice reverts #16 which was introduced due to a bug fixed in ruamel.yaml 0.15.44. For more details see #113, but the gist of it is that there is a difference between ruamel.yaml version 0.15.43 and 0.15.44 that makes us no longer need a previously added workaround to manage the 0.15.43 behavior.

```
pip install "ruamel.yaml==0.15.43" && \
python -c "import sys; import ruamel.yaml; ruamel.yaml.YAML(typ='rt').dump({'x': '008'}, sys.stdout)"
        
pip install "ruamel.yaml==0.15.44" && \
python -c "import sys; import ruamel.yaml; ruamel.yaml.YAML(typ='rt').dump({'x': '008'}, sys.stdout)"
```

Closes #113

## Motivation
@manics and I are working to setup pre-commit to autoformat yaml files, and chartpress coercing the image tags to single quotes for no good reason is disruptive for us. See https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1996#issue-556403858.