### PR TITLE
Add mock tests for public chartpress methods that call commands

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ from distutils.dir_util import copy_tree
 import git
 import pytest
 
+import chartpress
+
 
 @pytest.fixture(scope="function")
 def git_repo(monkeypatch):
@@ -72,3 +74,24 @@ def git_repo_alternative(monkeypatch, git_repo):
     r.index.commit("chartpress_alternative.yaml initial commit")
 
     yield r
+
+
+class MockCheckCall:
+    def __init__(self):
+        self.commands = []
+
+    def __call__(self, cmd, **kwargs):
+        self.commands.append((cmd, kwargs))
+
+
+@pytest.fixture(scope="function")
+def mock_check_call(monkeypatch):
+    """
+    Replace chartpress._check_call with a no-op version that records all commands
+    Also disable lcu_cache to prevent cached information being kept across test calls
+    """
+    mock_call = MockCheckCall()
+    monkeypatch.setattr(chartpress, "_check_call", mock_call)
+    monkeypatch.setattr(chartpress, "lru_cache", lambda func: func)
+
+    yield mock_call

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,207 @@
+# Unit tests for some chartpress methods
+from os import mkdir
+
+import pytest
+from ruamel.yaml import YAML
+
+import chartpress
+
+
+@pytest.mark.parametrize("with_args", [False, True])
+def test_build_image(mock_check_call, with_args):
+    image_spec = "index.docker.io/library/ubuntu:latest"
+    context_path = "dir"
+    dockerfile_path = None
+    build_args = None
+
+    if with_args:
+        dockerfile_path = "Dockerfile.custom"
+        # Ensure dict is ordered
+        build_args = {"arg": "value"}
+        build_args["b"] = 2
+
+    chartpress.build_image(image_spec, context_path, dockerfile_path, build_args)
+
+    assert len(mock_check_call.commands) == 1
+    if with_args:
+        assert mock_check_call.commands[0] == (
+            [
+                "docker",
+                "build",
+                "-t",
+                image_spec,
+                context_path,
+                "-f",
+                "Dockerfile.custom",
+                "--build-arg",
+                "arg=value",
+                "--build-arg",
+                "b=2",
+            ],
+            {},
+        )
+    else:
+        assert mock_check_call.commands[0] == (
+            [
+                "docker",
+                "build",
+                "-t",
+                image_spec,
+                context_path,
+            ],
+            {},
+        )
+
+
+@pytest.mark.parametrize("push", [False, True])
+@pytest.mark.parametrize("tag", [None, "1.2.3"])
+def test_build_images(git_repo, mock_check_call, push, tag):
+    prefix = "pre/"
+    images = {
+        "testimage": {
+            "buildArgs": {
+                "arg": "test",
+            },
+            "contextPath": "image",
+            "dockerfilePath": "image/Dockerfile",
+        },
+    }
+    images["imageName"] = {
+        "imageName": "custom-name",
+    }
+
+    chartpress.build_images(
+        prefix, images, tag=tag, force_build=True, push=push, force_push=push
+    )
+    sha = git_repo.commit(git_repo.head).hexsha
+
+    if tag:
+        expected_tag = tag
+    else:
+        expected_tag = f"0.0.1-n001.h{sha[:7]}"
+
+    expected_build1 = [
+        "docker",
+        "build",
+        "-t",
+        f"pre/testimage:{expected_tag}",
+        "image",
+        "-f",
+        "image/Dockerfile",
+        "--build-arg",
+        "arg=test",
+    ]
+    expected_build2 = [
+        "docker",
+        "build",
+        "-t",
+        f"custom-name:{expected_tag}",
+        "images/imageName",
+        "-f",
+        "images/imageName/Dockerfile",
+    ]
+
+    expected_push1 = ["docker", "push", f"pre/testimage:{expected_tag}"]
+    expected_push2 = ["docker", "push", f"custom-name:{expected_tag}"]
+
+    if push:
+        assert len(mock_check_call.commands) == 4
+        assert mock_check_call.commands[0] == (expected_build1, {})
+        assert mock_check_call.commands[1] == (expected_push1, {})
+        assert mock_check_call.commands[2] == (expected_build2, {})
+        assert mock_check_call.commands[3] == (expected_push2, {})
+    else:
+        assert len(mock_check_call.commands) == 2
+        assert mock_check_call.commands[0] == (expected_build1, {})
+        assert mock_check_call.commands[1] == (expected_build2, {})
+
+
+@pytest.mark.parametrize("version", [None, "1.2.3"])
+def test_build_chart(git_repo, mock_check_call, version):
+    yaml = YAML()
+
+    sha = git_repo.commit(git_repo.head).hexsha
+    mkdir("chart")
+    with open("chart/Chart.yaml", "w") as f:
+        yaml.dump({"version": "0", "name": "test-chart"}, f)
+
+    rv = chartpress.build_chart("chart", version=version, paths=[])
+
+    if version:
+        expected_version = version
+    else:
+        expected_version = f"0.0.1-n001.h{sha[:7]}"
+
+    assert rv == expected_version
+
+    with open("chart/Chart.yaml") as f:
+        chart = yaml.load(f)
+    assert chart == {"name": "test-chart", "version": expected_version}
+    assert len(mock_check_call.commands) == 0
+
+
+def test_publish_pages(git_repo, mock_check_call):
+    chartpress.publish_pages(
+        "test-chart",
+        "1.2.3",
+        "jupyterhub/chartpress",
+        "https://example.org/chartpress",
+        "<foo>",
+    )
+
+    assert mock_check_call.commands[0] == (
+        [
+            "git",
+            "clone",
+            "--no-checkout",
+            "git@github.com:jupyterhub/chartpress",
+            "test-chart-1.2.3",
+        ],
+        {"echo": True},
+    )
+    assert mock_check_call.commands[1] == (
+        ["git", "checkout", "gh-pages"],
+        {"cwd": "test-chart-1.2.3", "echo": True},
+    )
+
+    helm_package_cmd = mock_check_call.commands[2][0]
+    assert mock_check_call.commands[2][1] == {}
+    # Skip the temporary directory
+    assert (helm_package_cmd[:5] + helm_package_cmd[6:]) == [
+        "helm",
+        "package",
+        "test-chart",
+        "--dependency-update",
+        "--destination",
+    ]
+
+    helm_index_cmd = mock_check_call.commands[3][0]
+    assert mock_check_call.commands[3][1] == {}
+    # Skip the temporary directory
+    assert (helm_index_cmd[:3] + helm_index_cmd[4:]) == [
+        "helm",
+        "repo",
+        "index",
+        "--url",
+        "https://example.org/chartpress",
+        "--merge",
+        "test-chart-1.2.3/index.yaml",
+    ]
+
+    assert mock_check_call.commands[4] == (
+        ["git", "add", "."],
+        {"cwd": "test-chart-1.2.3"},
+    )
+    assert mock_check_call.commands[5] == (
+        [
+            "git",
+            "commit",
+            "-m",
+            "[test-chart] Automatic update for commit 1.2.3\n\n<foo>",
+        ],
+        {"cwd": "test-chart-1.2.3"},
+    )
+    assert mock_check_call.commands[6] == (
+        ["git", "push", "origin", "gh-pages"],
+        {"cwd": "test-chart-1.2.3"},
+    )


### PR DESCRIPTION
Adds some unit tests that mock the `chartpress._check_call` method, which means we can test more combinations of input arguments without complicated setups.

Ideally these tests should test all variations of all input arguments, but we can add them in future whenever the method is modified (unless someone else wants to push to this PR).