### PR TITLE
Add skipPlatforms option for multi-platform docker buildx images

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,18 @@ In a directory containing a `chartpress.yaml`, run:
 to build your chart(s) and image(s). Add `--push` to publish images to docker
 hub and `--publish-chart` to publish the chart and index to gh-pages.
 
+<!--
+To update this help output run
+COLUMNS=80 chartpress --help
+-->
+
 ```
 usage: chartpress [-h] [--push] [--force-push] [--publish-chart]
                   [--force-publish-chart] [--extra-message EXTRA_MESSAGE]
                   [--tag TAG | --long] [--image-prefix IMAGE_PREFIX] [--reset]
-                  [--no-build | --force-build] [--list-images] [--version]
+                  [--no-build | --force-build]
+                  [--builder {docker-build,docker-buildx}]
+                  [--platform PLATFORM] [--list-images] [--version]
 
 Automate building and publishing helm charts and associated images. This is
 used as part of the JupyterHub and Binder projects.
@@ -127,6 +134,15 @@ optional arguments:
                         Skip the image build step.
   --force-build         Enforce the image build step, regardless of if the
                         image already is available either locally or remotely.
+  --builder {docker-build,docker-buildx}
+                        Container build engine to use, docker-build is the
+                        standard Docker build command.
+  --platform PLATFORM   Build the image for this platform, e.g. linux/amd64 or
+                        linux/arm64. This argument can be used multiple times
+                        to build multiple platforms under the same tag. Only
+                        supported for docker buildx. If --push is set or if
+                        multiple platforms are passed the image will not be
+                        loaded into the local docker engine.
   --list-images         print list of images to stdout. Images will not be
                         built.
   --version             Print current chartpress version and exit.
@@ -197,6 +213,11 @@ charts:
         # from the contextPath and dockerfilePath for building the image itself.
         paths:
           - assets
+        # If chartpress is used to build images for multiple architectures but
+        # not all of those architectures are supported by an image they can be
+        # skipped
+        skipPlatforms:
+          - linux/arm64
 ```
 
 ## Caveats

--- a/chartpress.py
+++ b/chartpress.py
@@ -591,6 +591,13 @@ def build_images(
 
         image_spec = f"{image_name}:{image_tag}"
 
+        skip_platforms = options.get("skipPlatforms", [])
+        if platforms and skip_platforms:
+            platforms = set(platforms).difference(skip_platforms)
+            if not platforms:
+                _log(f"Skipping build for {image_spec}, no matching platforms")
+                continue
+
         # build image and optionally push image
         if force_build or _image_needs_building(image_spec, builder):
             build_image(

--- a/tests/test_helm_chart/amd64only/Dockerfile
+++ b/tests/test_helm_chart/amd64only/Dockerfile
@@ -1,0 +1,2 @@
+# Using busybox just so we can distinguish between the two built images in the logs
+FROM docker.io/library/busybox

--- a/tests/test_helm_chart/chartpress.yaml
+++ b/tests/test_helm_chart/chartpress.yaml
@@ -21,3 +21,8 @@ charts:
           - list.1.image
         paths:
           - extra-image-path.txt
+      amd64only:
+        contextPath: amd64only
+        skipPlatforms:
+          - linux/arm64
+          - linux/ppc64le

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -136,7 +136,11 @@ def test__get_image_build_args(git_repo):
                     "TAG": "tag",
                 },
             )
-            assert build_args == {
-                "TEST_STATIC_BUILD_ARG": "test",
-                "TEST_DYNAMIC_BUILD_ARG": "tag-sha",
-            }
+            assert name in ("testimage", "amd64only")
+            if name == "testimage":
+                assert build_args == {
+                    "TEST_STATIC_BUILD_ARG": "test",
+                    "TEST_DYNAMIC_BUILD_ARG": "tag-sha",
+                }
+            else:
+                assert build_args == {}


### PR DESCRIPTION
In Z2JH the [singleuser image can only be built for `linux/amd64`](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/08faa6f197e478ca28ce23d083287d37096cbb36/images/singleuser-sample/Dockerfile#L1) as it depends on https://github.com/jupyter/docker-stacks/. This means we need a way to omit selected images when building a multi-image multi-architecture chart.