### PR TITLE
fix: use of github workflow tokens - different from PATs

### DIFF
--- a/chartpress.py
+++ b/chartpress.py
@@ -24,6 +24,7 @@ __version__ = "1.2.1.dev"
 
 # name of the environment variable with GitHub token
 GITHUB_TOKEN_KEY = "GITHUB_TOKEN"
+GITHUB_ACTOR_KEY = "GITHUB_ACTOR"
 
 # name of possible repository keys used in image value
 IMAGE_REPOSITORY_KEYS = {"name", "repository"}
@@ -114,8 +115,15 @@ def _get_git_remote_url(git_repo):
     if not re.match(r"^[^/]+/[^/]+$", git_repo):
         return git_repo
 
+    github_actor = os.getenv(GITHUB_ACTOR_KEY)
     github_token = os.getenv(GITHUB_TOKEN_KEY)
-    if github_token:
+    if github_actor and github_token:
+        # this format works for a token created for a github
+        # workflow's job, no matter what we pass as github_actor.
+        return f"https://{github_actor}:{github_token}@github.com/{git_repo}"
+    elif github_token:
+        # this format works for personal access token, but
+        # not for a token created for a github workflow's job.
         return f"https://{github_token}@github.com/{git_repo}"
     return f"git@github.com:{git_repo}"
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,6 +8,7 @@ from chartpress import _get_latest_commit_tagged_or_modifying_paths
 from chartpress import _image_needs_pushing
 from chartpress import _strip_build_suffix_from_identifier
 from chartpress import Builder
+from chartpress import GITHUB_ACTOR_KEY
 from chartpress import GITHUB_TOKEN_KEY
 
 # use safe roundtrip yaml loader
@@ -67,7 +68,14 @@ def test__get_identifier_from_parts():
 
 
 def test__get_git_remote_url(monkeypatch):
+    monkeypatch.setenv(GITHUB_ACTOR_KEY, "test-github-actor")
     monkeypatch.setenv(GITHUB_TOKEN_KEY, "test-github-token")
+    assert (
+        _get_git_remote_url("jupyterhub/helm-chart")
+        == "https://test-github-actor:test-github-token@github.com/jupyterhub/helm-chart"
+    )
+
+    monkeypatch.delenv(GITHUB_ACTOR_KEY)
     assert (
         _get_git_remote_url("jupyterhub/helm-chart")
         == "https://test-github-token@github.com/jupyterhub/helm-chart"


### PR DESCRIPTION
Closes #131 - this has bugged me a long time! I got confused by the fact that personal access tokens behaved differently from the `${{ github.token }}` one can get from a github workflow.

I've tested this well manually now, actually by setting up a dummy repo and running it via SSH etc.