### PR TITLE
remove unused _strip_build_suffix_from_identifier

### DIFF
--- a/chartpress.py
+++ b/chartpress.py
@@ -503,26 +503,6 @@ def _get_identifier_from_parts(tag, n_commits, commit, long):
         return f"{tag}"
 
 
-def _strip_build_suffix_from_identifier(identifier):
-    """
-    Return a stripped chart version or image tag (identifier) without its build
-    suffix (.n005.hasdf1234), leaving it to represent a Semver 2 release or
-    pre-release.
-
-    Example:
-        identifier: "0.1.2-n005.hasdf1234"            returns: "0.1.2"
-        identifier: "0.1.2-alpha.1.n005.hasdf1234"    returns: "0.1.2-alpha.1"
-    """
-    # split away official SemVer 2 build specifications if used
-    if "+" in identifier:
-        return identifier.split("+", maxsplit=1)[0]
-
-    # split away our custom build specification: something ending in either
-    # . or - followed by three or more digits, a dot, an commit sha of four
-    # or more alphanumeric characters.
-    return re.sub(r"[-\.]n\d{3,}\.h\w{4,}\Z", "", identifier)
-
-
 def build_images(
     prefix,
     images,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,7 +6,6 @@ from chartpress import _get_identifier_from_parts
 from chartpress import _get_image_build_args
 from chartpress import _get_latest_commit_tagged_or_modifying_paths
 from chartpress import _image_needs_pushing
-from chartpress import _strip_build_suffix_from_identifier
 from chartpress import Builder
 from chartpress import GITHUB_ACTOR_KEY
 from chartpress import GITHUB_TOKEN_KEY
@@ -15,17 +14,6 @@ from chartpress import GITHUB_TOKEN_KEY
 yaml = YAML(typ="rt")
 yaml.preserve_quotes = True  ## avoid mangling of quotes
 yaml.indent(mapping=2, offset=2, sequence=4)
-
-
-def test__strip_build_suffix_from_identifier():
-    assert (
-        _strip_build_suffix_from_identifier(identifier="0.1.2-n005.hasdf1234")
-        == "0.1.2"
-    )
-    assert (
-        _strip_build_suffix_from_identifier(identifier="0.1.2-alpha.1.n005.hasdf1234")
-        == "0.1.2-alpha.1"
-    )
 
 
 def test__get_identifier_from_parts():


### PR DESCRIPTION
`_strip_build_suffix_from_identifier` isn't used, and it has a `_` prefix indicating it's internal.