### PR TITLE
Allow extra options to be passed to docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,12 +200,6 @@ charts:
           - --label=maintainer=octocat
           - --label=ref={TAG}-{LAST_COMMIT}
           - --rm
-          # above is equivalent to
-          - --label
-          - maintainer=octocat
-          - --label
-          - ref={TAG}-{LAST_COMMIT}
-          - --rm
         # contextPath is the path to the directory that is to be considered the
         # current working directory during the build process of the Dockerfile.
         # This is by default the folder of the Dockerfile. This path should be

--- a/README.md
+++ b/README.md
@@ -192,13 +192,20 @@ charts:
         buildArgs:
           MY_STATIC_BUILD_ARG: "hello world"
           MY_DYNAMIC_BUILD_ARG: "{TAG}-{LAST_COMMIT}"
-        # Build options to be passed to docker build as --<key> <value>. This
-        # allows you to use all available docker options for your build.
-        # The example below adds "--ssh default=secrets/private-key" to the build 
-        # command. Note that for flags like "--ssh" which take a key-value pair,
-        # you must use the "key=value" syntax and not "key value".
-        extraOptions:
-          ssh: default=secrets/private-key
+        # Build options to be passed to the docker build command. Pass a list
+        # of strings to be appended to the end of the build command. These are
+        # passed directly to the command line, so prepend each option with "--"
+        # like in the examples below. TAG and LAST_COMMIT are expandable.
+        extraBuildCommandOptions:
+          - --label=maintainer=octocat
+          - --label=ref={TAG}-{LAST_COMMIT}
+          - --rm
+          # above is equivalent to
+          - --label
+          - maintainer=octocat
+          - --label
+          - ref={TAG}-{LAST_COMMIT}
+          - --rm
         # contextPath is the path to the directory that is to be considered the
         # current working directory during the build process of the Dockerfile.
         # This is by default the folder of the Dockerfile. This path should be

--- a/README.md
+++ b/README.md
@@ -192,6 +192,13 @@ charts:
         buildArgs:
           MY_STATIC_BUILD_ARG: "hello world"
           MY_DYNAMIC_BUILD_ARG: "{TAG}-{LAST_COMMIT}"
+        # Build options to be passed to docker build as --<key> <value>. This
+        # allows you to use all available docker options for your build.
+        # The example below adds "--ssh default=secrets/private-key" to the build 
+        # command. Note that for flags like "--ssh" which take a key-value pair,
+        # you must use the "key=value" syntax and not "key value".
+        extraOptions:
+          ssh: default=secrets/private-key
         # contextPath is the path to the directory that is to be considered the
         # current working directory during the build process of the Dockerfile.
         # This is by default the folder of the Dockerfile. This path should be

--- a/chartpress.py
+++ b/chartpress.py
@@ -240,14 +240,13 @@ def _get_image_extra_build_command_options(image_options, ns):
     """
     Render extraBuildCommandOptions from chartpress.yaml that could be
     templates, using the provided namespace that contains keys with dynamic
-    values such as LAST_COMMIT or TAG. The rendered options will be converted
-    to a list of strings that can be added to the build command list.
+    values such as LAST_COMMIT or TAG.
 
     Args:
     image_options (dict):
         The dictionary for a given image from chartpress.yaml.
-        Fields in `image_options['extraBuildCommandOptions']` will be rendered
-        and then converted to option strings to add to the build command.
+        Strings in `image_options['extraBuildCommandOptions']` will be rendered
+        and returned.
     ns (dict): the namespace used when rendering templated arguments
     """
     options = image_options.get("extraBuildCommandOptions", [])
@@ -341,9 +340,8 @@ def build_image(
     build_args (dict, optional):
         Dictionary of docker build arguments.
     extra_build_command_options (list, optional):
-        List of other docker build options to use. Each item can be either a
-        string with the option name (e.g. "rm") or a dictionary with the key
-        and value (e.g. "label: 'maintainer=octocat'").
+        List of other docker build options to use. Each item should be a string
+        that gets appended to the build command (e.g. "--label=version=0.1.0").
     push (bool, optional):
         Whether to push the image to a registry
     builder (str):

--- a/chartpress.py
+++ b/chartpress.py
@@ -377,7 +377,8 @@ def build_image(
             cmd.append("--push")
         elif len(platforms) <= 1:
             cmd.append("--load")
-    cmd.extend((extra_build_command_options or []))
+    if extra_build_command_options:
+        cmd.extend(extra_build_command_options)
     _check_call(cmd)
 
     if builder == Builder.DOCKER_BUILD and push:

--- a/chartpress.py
+++ b/chartpress.py
@@ -296,6 +296,7 @@ def build_image(
     context_path,
     dockerfile_path=None,
     build_args=None,
+    extra_options=None,
     *,
     push=False,
     builder=Builder.DOCKER_BUILD,
@@ -321,6 +322,11 @@ def build_image(
         "<context_path>/Dockerfile".
     build_args (dict, optional):
         Dictionary of docker build arguments.
+    extra_options (dict, optional):
+        Dictionary of other docker build options to use. Each key should be a
+        valid option to docker build, like "ssh" for the "--ssh" option. For 
+        flags like "--ssh" which take a key-value pair, make sure to use the
+        "key=value" syntax and not the "key value" syntax.
     push (bool, optional):
         Whether to push the image to a registry
     builder (str):
@@ -344,6 +350,8 @@ def build_image(
         cmd.extend(["-f", dockerfile_path])
     for k, v in (build_args or {}).items():
         cmd += ["--build-arg", f"{k}={v}"]
+    for k, v in (extra_options or {}).items():
+        cmd += [f"--{k}", f"{v}"]
     if platforms:
         # sort platforms to make testing easier
         cmd.extend(["--platform", ",".join(sorted(platforms))])
@@ -605,6 +613,7 @@ def build_images(
                         "TAG": image_tag,
                     },
                 ),
+                extra_options=options.get("extraOptions", {}),
                 push=push or force_push,
                 builder=builder,
                 platforms=platforms,

--- a/tests/test_helm_chart/chartpress.yaml
+++ b/tests/test_helm_chart/chartpress.yaml
@@ -13,6 +13,11 @@ charts:
         buildArgs:
           TEST_STATIC_BUILD_ARG: "test"
           TEST_DYNAMIC_BUILD_ARG: "{TAG}-{LAST_COMMIT}"
+        extraBuildCommandOptions:
+          - --label=maintainer=octocat
+          - --label
+          - ref={TAG}-{LAST_COMMIT}
+          - --rm
         contextPath: image
         dockerfilePath: image/Dockerfile
         valuesPath:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,6 +5,7 @@ from chartpress import _check_call
 from chartpress import _get_git_remote_url
 from chartpress import _get_identifier_from_parts
 from chartpress import _get_image_build_args
+from chartpress import _get_image_extra_build_command_options
 from chartpress import _get_latest_commit_tagged_or_modifying_paths
 from chartpress import _image_needs_pushing
 from chartpress import Builder
@@ -156,3 +157,25 @@ def test__get_image_build_args(git_repo):
                 }
             else:
                 assert build_args == {}
+
+
+def test__get_image_extra_build_command_options(git_repo):
+    with open("chartpress.yaml") as f:
+        config = yaml.load(f)
+    for chart in config["charts"]:
+        for name, options in chart["images"].items():
+            extra_build_command_options = _get_image_extra_build_command_options(
+                options,
+                {
+                    "LAST_COMMIT": "sha",
+                    "TAG": "tag",
+                },
+            )
+            assert name in ("testimage", "amd64only")
+            if name == "testimage":
+                assert extra_build_command_options == [
+                    "--label=maintainer=octocat",
+                    "--label",
+                    "ref=tag-sha",
+                    "--rm",
+                ]


### PR DESCRIPTION
This is a first pass at implementing #141 (Ability to include extra options to `docker build`). It allows users to specify extra build options in *chartpress.yaml* on a per-image basis. This is useful for taking advantage of other build options that chartpress does not explicitly support. 

I am not very familiar with pytest, so there are no tests included here. I can confirm that it is working using the --ssh option to clone a private GitHub repo in my local builds. 

