### PR TITLE
Drop support for py36 and misc ci maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# dependabot.yml reference: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+#
+# Notes:
+# - Status and logs from dependabot are provided at
+#   https://github.com/jupyterhub/chartpress/network/updates.
+# - YAML anchors are not supported here or in GitHub Workflows.
+#
+
+version: 2
+updates:
+  # Maintain dependencies in our GitHub Workflows
+  - package-ecosystem: "github-actions"
+    directory: "/" # This should be / rather than .github/workflows
+    schedule:
+      interval: daily
+      time: "05:00"
+      timezone: "Etc/UTC"
+    labels:
+      - maintenance
+      - dependencies

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: "3.9"
 
       - name: install build package
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,8 +6,21 @@
 name: Publish
 
 on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - ".github/workflows/*"
+      - "!.github/workflows/publish.yaml"
   push:
-    tags: v?[0-9]+.[0-9]+.[0-9]+*
+    paths-ignore:
+      - "**.md"
+      - ".github/workflows/*"
+      - "!.github/workflows/publish.yaml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags:
+      - "**"
 
 jobs:
   publish-to-pypi:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,13 +3,20 @@
 #
 name: Test
 
-# Trigger the workflow's on all PRs but only on pushed tags or commits to main
-# branch to avoid PRs developed in a GitHub fork's dedicated branch to trigger.
 on:
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - ".github/workflows/*"
+      - "!.github/workflows/test.yaml"
   push:
-    branches:
-    tags:
+    paths-ignore:
+      - "**.md"
+      - ".github/workflows/*"
+      - "!.github/workflows/test.yaml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,13 +13,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
-
   chart-tests:
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,9 +31,8 @@ jobs:
         # specified below, these parameters have no meaning on their own and
         # gain meaning on how job steps use them.
         include:
-          - python: "3.6"
-            helm2: helm2
           - python: "3.7"
+            helm2: helm2
           - python: "3.8"
           - python: "3.9"
           - python: "3.10"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,11 +24,12 @@ jobs:
         # specified below, these parameters have no meaning on their own and
         # gain meaning on how job steps use them.
         include:
-          - python: 3.6
+          - python: "3.6"
             helm2: helm2
-          - python: 3.7
-          - python: 3.8
-          - python: 3.9
+          - python: "3.7"
+          - python: "3.8"
+          - python: "3.9"
+          - python: "3.10"
 
     services:
       local-registry:

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     license="BSD",
     platforms="Linux, Mac OS X",
     keywords=["helm", "kubernetes"],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "ruamel.yaml>=0.15.44",
         # Bug in 5.0.0: https://github.com/docker/docker-py/pull/2844

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -104,10 +104,7 @@ def test_chartpress_run(git_repo, capfd):
     )
 
     # verify output of --publish-chart
-    assert (
-        "Branch 'gh-pages' set up to track remote branch 'gh-pages' from 'origin'."
-        in out
-    )
+    assert "'gh-pages' set up to track" in out
     assert "Successfully packaged chart and saved it to:" in out
     assert f"/testchart-{tag}.tgz" in out
 
@@ -169,10 +166,7 @@ def test_chartpress_run(git_repo, capfd):
     )
 
     # verify output of --publish-chart
-    assert (
-        "Branch 'gh-pages' set up to track remote branch 'gh-pages' from 'origin'."
-        in out
-    )
+    assert "'gh-pages' set up to track" in out
     assert "Successfully packaged chart and saved it to:" in out
     assert f"/testchart-{tag}.n001.h{sha}.tgz" in out
     assert f"Skipping chart publishing" not in out


### PR DESCRIPTION
I saw that our pre-commit check failed in a PR (#142) without automatically adding a commit to fix it. I wanted to make use of the pre-commit.ci service to help out with that, so I enabled it for the repo, and I removed the pre-commit check we manually run in a github workflow.

Along with doing that, I updated some misc workflow details and removed support for Python 3.6 that has reached end of life.

There was also a test failure related to having hardcoded a logs output comparison that changed between git versions.