### PR TITLE
Add tests with dev tags and backport branches

### DIFF
--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -1,5 +1,5 @@
 import os
-import sys
+import re
 
 import chartpress
 
@@ -304,3 +304,28 @@ def _capture_output(args, capfd, expect_output=False):
         assert out == ""
 
     return err
+
+
+def test_dev_tag(git_repo_dev_tag, capfd):
+    r = git_repo_dev_tag
+    out = _capture_output(["--skip-build"], capfd)
+    version_string = re.search(r"version:\s+(.+)", out, re.MULTILINE).group(1)
+    chartpress._fix_chart_version(version_string, strict=True)
+    v, _, pre = version_string.partition("-")
+    # make sure we make a correct prerelease tag
+    # when merging with an existing '-pre' tag
+    # (i.e. join with '.', not multiple '-' separators)
+    assert "-" not in pre
+    assert v == "2.0.0"
+    assert pre.split(".")[:2] == ["dev", "n001"]
+
+
+def test_backport_branch(git_repo_backport_branch, capfd):
+    r = git_repo_backport_branch
+    out = _capture_output(["--skip-build"], capfd)
+    version_string = re.search(r"version:\s+(.+)", out, re.MULTILINE).group(1)
+    chartpress._fix_chart_version(version_string, strict=True)
+    v, _, pre = version_string.partition("-")
+    assert "-" not in pre
+    assert v == "1.0.1"
+    assert pre.split(".")[:1] == ["n001"]


### PR DESCRIPTION
everything seems to work without fixing, but good to test anyway

related to #143, looks like we handle `2.0.0-dev` tags just fine.