### PR TITLE
Add `useChartVersion` and change appended version suffix (now like `1.2.3-0.dev.git.3.h123`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,22 +25,25 @@ Chartpress will infer chart versions and image tags using a few key pieces of
 information.
 
 1. `tag`: If not directly set by `--tag`, it will be inferred from most recent
-   commit that is tagged in the _current branch_, or be set to 0.0.1 if no
-   commit is tagged.
+   commit that is tagged in the _current branch_
+   (as determined by `git describe`)
+   or be set to 0.0.1 if no commit is tagged.
    1. If the `tag` has a leading `v` but is otherwise a valid
-      [SemVer2](https://semver.org) version, it will be stripped from Chart.yaml
+      [SemVer2](https://semver.org) version, the `v` will be stripped from Chart.yaml
       before its set as Helm 3 requires Helm chart versions to be SemVer2
       compliant.
 1. The latest commit modifying content in a _relevant path_ since `tag`.
-   1. `n`: The latest commit's distance to the tagged commit, described as 3 or
-      more numbers, prefixed with n.
+   1. `n`: The number of commits since the tagged commit, as an integer.
    1. `h`: The latest commit's abbreviated hash. which is often 7-8 characters,
-      prefixed with h.
-1. If `tag` (like `0.10.0` or `0.10.0-beta.1`) contains a `-`, a `tag.n.h`
-   format will be used instead of a `tag-n.h` format to be SemVer 2 compliant.
+      prefixed with `h`.
+1. If `tag` (like `0.10.0` or `0.10.0-beta.1`) contains `-`,
+   indicating that it is a prerelease,
+   the chartpress suffix will be added to the prerelease fields,
+   e.g. `0.10.0-beta.1.0git.5.habc123`
+   format will be used instead of a `tag-0git.n.h` format to be SemVer 2 compliant.
 1. If `--long` is specified or not. If `--long` is specified, tagged commits
-   will be written out with the `n.h` part appended to it, looking something
-   like `n000.gabcd123`
+   will always be written out with the `n.h` part appended to it, looking something
+   like `1.0.0-0git.0.habcd123`
 
 ### Examples chart versions and image tags
 
@@ -49,13 +52,13 @@ order that could come from using chartpress.
 
 ```
 0.8.0
-0.8.0-n004.hasdf123
-0.8.0-n010.hsdfg234
+0.8.0-0git.4.hasdf123
+0.8.0-0git.10.hsdfg234
 0.9.0-beta.1
-0.9.0-beta.1.n001.hdfgh345
-0.9.0-beta.1.n005.hfghj456
+0.9.0-beta.1.0git.1.hdfgh345
+0.9.0-beta.1.0git.5.hfghj456
 0.9.0-beta.2
-0.9.0-beta.2.n001.hghjk567
+0.9.0-beta.2.0git.1.hghjk567
 0.9.0-beta.3
 0.9.0
 ```

--- a/README.md
+++ b/README.md
@@ -33,16 +33,13 @@ information.
       before its set as Helm 3 requires Helm chart versions to be SemVer2
       compliant.
 1. The latest commit modifying content in a _relevant path_ since `tag`.
-   1. `n`: The number of commits since the tagged commit, as an integer.
-   1. `h`: The latest commit's abbreviated hash. which is often 7-8 characters,
+   1. `n`: The number of commits since the latest tagged commit on the branch, as an integer.
+   1. `hash`: The latest commit's abbreviated hash, which is often 7-8 characters,
       prefixed with `h`.
-1. If `tag` (like `0.10.0` or `0.10.0-beta.1`) contains `-`,
-   indicating that it is a prerelease,
-   the chartpress suffix will be added to the prerelease fields,
-   e.g. `0.10.0-beta.1.git.5.habc123`
-   format will be used instead of a `tag-0.dev.git.n.h` format to be SemVer 2 compliant.
+1. If `tag` (like `0.10.0` or `0.10.0-beta.1`) contains a `-`, a `tag.git.n.hash`
+   format will be used, and otherwise a `tag-0.dev.git.n.hash` format will be used.
 1. If `--long` is specified or not. If `--long` is specified, tagged commits
-   will always be written out with the `n.h` part appended to it, looking something
+   will always be written out with the `.git.n.hash` part appended to it, looking something
    like `1.0.0-0.dev.git.0.habcd123`
 
 When producing a development version (with `.git.n.hash` on the end),

--- a/chartpress.py
+++ b/chartpress.py
@@ -787,8 +787,10 @@ def build_chart(
     Update Chart.yaml's version, using specified version or by constructing one.
 
     Chart versions are constructed using:
-        a) a base version, derived from either Chart.yaml or the latest tag
-        b) the latest commit that modified provided paths
+        a) a base version, derived from either Chart.yaml's version field or the latest git tag on branch
+        b) the latest commit that was tagged on the current branch (n)
+        c) the latest commit that modified provided paths (hash)
+        
 
     Example versions constructed:
         - 0.9.0-0.dev.git.2.hdfgh3456
@@ -1117,7 +1119,6 @@ def main(args=None):
     #   - push chart (--publish-chart, --extra-message)
     for chart in config["charts"]:
         forced_version = None
-        # TODO: maybe warn and switch default in the future?
         use_chart_version = chart.get("useChartVersion", False)
 
         if args.tag:
@@ -1126,7 +1127,7 @@ def main(args=None):
         elif args.reset and not use_chart_version:
             # resetting, get version from chartpress.yaml,
             # ignoring current version in Chart.yaml
-            forced_version = chart.get("resetVersion", "0.0.1-0.dev")
+            forced_version = chart.get("resetVersion", "0.0.1-set.by.chartpress")
 
         if not args.list_images:
             # update Chart.yaml with a version

--- a/chartpress.py
+++ b/chartpress.py
@@ -1076,7 +1076,7 @@ def main(args=None):
             # tag specified, use that version
             forced_version = args.tag
         elif args.reset and not use_chart_version:
-            # resetting, get version from chrtpress.yaml,
+            # resetting, get version from chartpress.yaml,
             # ignoring current version in Chart.yaml
             forced_version = chart.get("resetVersion", "0.0.1-0.dev")
 

--- a/chartpress.py
+++ b/chartpress.py
@@ -790,16 +790,23 @@ def build_chart(
             if "set.by.chartpress" in chart["version"]:
                 raise ValueError(
                     f"Chart {chart_file} has placeholder version {chart['version']}, with `useChartVersion: true`."
-                    f"Set the version in the {chart_file} to a base pre-release tag,"
-                    " e.g. `1.0.0-0.dev` or `1.0.0-alpha.1` and run chartpress again."
+                    f" Set the version in the {chart_file} to a base pre-release tag (your _next_ release),"
+                    " e.g. `2.0.0-0.dev` or `2.0.0-alpha.1` and run chartpress again."
                 )
 
             # require starting from a prerelease tag, to ensure correct ordering
             if "-" not in chart["version"]:
+                if reset:
+                    raise ValueError(
+                        "--reset after a release must also specify --tag $VERSION to reset to"
+                        " when using useChartVersion: true."
+                        " This should be your _next_ pre-release version,"
+                        " e.g. `chartpress --reset --tag 1.0.1-0.dev`"
+                    )
                 raise ValueError(
                     f"Chart {chart_file} has non-prerelease version {chart['version']} with `useChartVersion: true`"
-                    f"Set the version in the {chart_file} to a base pre-release tag,"
-                    " e.g. `1.0.0-0.dev` or `1.0.0-alpha.1` and run chartpress again."
+                    f" Set the version in the {chart_file} to a base pre-release tag (your _next_ release),"
+                    " e.g. `2.0.0-0.dev` or `2.0.0-alpha.1` and run chartpress again."
                 )
         else:
             base_version = None

--- a/chartpress.py
+++ b/chartpress.py
@@ -790,7 +790,7 @@ def build_chart(
         a) a base version, derived from either Chart.yaml's version field or the latest git tag on branch
         b) the latest commit that was tagged on the current branch (n)
         c) the latest commit that modified provided paths (hash)
-        
+
 
     Example versions constructed:
         - 0.9.0-0.dev.git.2.hdfgh3456

--- a/tests/test_chartpress.py
+++ b/tests/test_chartpress.py
@@ -8,6 +8,8 @@ from uuid import uuid4
 
 import pytest
 
+from chartpress import PRERELEASE_PREFIX
+
 
 def test_list_images(git_repo):
     p = run(
@@ -25,7 +27,7 @@ def test_list_images(git_repo):
     assert len(images) == 1
     # split hash_suffix which will be different every run
     pre_hash, hash_suffix = images[0].rsplit(".", 1)
-    assert pre_hash == "testchart/testimage:0.0.1-0git.1"
+    assert pre_hash == f"testchart/testimage:0.0.1-{PRERELEASE_PREFIX}.1"
 
     p = run(
         ["git", "status", "--porcelain"],
@@ -64,7 +66,7 @@ def _get_architectures_from_manifest(name, tag):
 
 
 @pytest.mark.registry
-def test_buildx(git_repo):
+def test_buildx(git_repo, capfd):
     tag = f"1.2.3-{uuid4()}"
     p = run(
         [
@@ -86,11 +88,10 @@ def test_buildx(git_repo):
             tag,
         ],
         check=True,
-        stdout=PIPE,
-        stderr=PIPE,
     )
-    stdout = p.stdout.decode("utf8").strip()
-    stderr = p.stderr.decode("utf8").strip()
+    stdout, stderr = capfd.readouterr()
+    # stdout = p.stdout.decode("utf8").strip()
+    # stderr = p.stderr.decode("utf8").strip()
     # echo stdout/stderr for debugging
     sys.stderr.write(stderr)
     sys.stdout.write(stdout)

--- a/tests/test_chartpress.py
+++ b/tests/test_chartpress.py
@@ -25,7 +25,7 @@ def test_list_images(git_repo):
     assert len(images) == 1
     # split hash_suffix which will be different every run
     pre_hash, hash_suffix = images[0].rsplit(".", 1)
-    assert pre_hash == "testchart/testimage:0.0.1-n001"
+    assert pre_hash == "testchart/testimage:0.0.1-0git.1"
 
     p = run(
         ["git", "status", "--porcelain"],

--- a/tests/test_chartpress.py
+++ b/tests/test_chartpress.py
@@ -84,11 +84,8 @@ def test_buildx(git_repo, capfd):
             tag,
         ],
         check=True,
-        capture_output=True,
     )
     stdout, stderr = capfd.readouterr()
-    # stdout = p.stdout.decode("utf8").strip()
-    # stderr = p.stderr.decode("utf8").strip()
     # echo stdout/stderr for debugging
     sys.stderr.write(stderr)
     sys.stdout.write(stdout)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -79,7 +79,7 @@ def test_build_images(git_repo, mock_check_call, push, tag):
     if tag:
         expected_tag = tag
     else:
-        expected_tag = f"0.0.1-{PRERELEASE_PREFIX}1.h{sha[:7]}"
+        expected_tag = f"0.0.1-{PRERELEASE_PREFIX}.1.h{sha[:7]}"
 
     expected_build1 = [
         "docker",
@@ -169,7 +169,7 @@ def test_buildx_images(
     if tag:
         expected_tag = tag
     else:
-        expected_tag = f"0.0.1-{PRERELEASE_PREFIX}1.h{sha[:7]}"
+        expected_tag = f"0.0.1-{PRERELEASE_PREFIX}.1.h{sha[:7]}"
 
     expected_build1 = [
         "docker",
@@ -273,7 +273,7 @@ def test_build_chart(git_repo, mock_check_call, version):
     if version:
         expected_version = version
     else:
-        expected_version = f"0.0.1-{PRERELEASE_PREFIX}1.h{sha[:7]}"
+        expected_version = f"0.0.1-{PRERELEASE_PREFIX}.1.h{sha[:7]}"
 
     assert rv == expected_version
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -5,6 +5,7 @@ import pytest
 from ruamel.yaml import YAML
 
 import chartpress
+from chartpress import PRERELEASE_PREFIX
 
 
 @pytest.mark.parametrize("with_args", [False, True])
@@ -78,7 +79,7 @@ def test_build_images(git_repo, mock_check_call, push, tag):
     if tag:
         expected_tag = tag
     else:
-        expected_tag = f"0.0.1-n001.h{sha[:7]}"
+        expected_tag = f"0.0.1-{PRERELEASE_PREFIX}1.h{sha[:7]}"
 
     expected_build1 = [
         "docker",
@@ -168,7 +169,7 @@ def test_buildx_images(
     if tag:
         expected_tag = tag
     else:
-        expected_tag = f"0.0.1-n001.h{sha[:7]}"
+        expected_tag = f"0.0.1-{PRERELEASE_PREFIX}1.h{sha[:7]}"
 
     expected_build1 = [
         "docker",
@@ -272,7 +273,7 @@ def test_build_chart(git_repo, mock_check_call, version):
     if version:
         expected_version = version
     else:
-        expected_version = f"0.0.1-n001.h{sha[:7]}"
+        expected_version = f"0.0.1-{PRERELEASE_PREFIX}1.h{sha[:7]}"
 
     assert rv == expected_version
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,4 @@
 import pytest
-from ruamel.yaml import YAML
 
 from chartpress import _check_call
 from chartpress import _fix_chart_version
@@ -16,12 +15,12 @@ from chartpress import yaml
 @pytest.mark.parametrize(
     "tag, n_commits, commit, long, expected",
     [
-        ("0.1.2", "0", "asdf123", True, "0.1.2-0git.0.hasdf123"),
+        ("0.1.2", "0", "asdf123", True, "0.1.2-0.dev.git.0.hasdf123"),
         ("0.1.2", "0", "asdf123", False, "0.1.2"),
-        ("0.1.2", "5", "asdf123", False, "0.1.2-0git.5.hasdf123"),
-        ("0.1.2-alpha.1", "0", "asdf1234", True, "0.1.2-alpha.1.0git.0.hasdf1234"),
+        ("0.1.2", "5", "asdf123", False, "0.1.2-0.dev.git.5.hasdf123"),
+        ("0.1.2-alpha.1", "0", "asdf1234", True, "0.1.2-alpha.1.git.0.hasdf1234"),
         ("0.1.2-alpha.1", "0", "asdf1234", False, "0.1.2-alpha.1"),
-        ("0.1.2-alpha.1", "5", "asdf1234", False, "0.1.2-alpha.1.0git.5.hasdf1234"),
+        ("0.1.2-alpha.1", "5", "asdf1234", False, "0.1.2-alpha.1.git.5.hasdf1234"),
     ],
 )
 def test_get_identifier_from_parts(tag, n_commits, commit, long, expected):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -4,7 +4,6 @@ from chartpress import (
     GITHUB_ACTOR_KEY,
     GITHUB_TOKEN_KEY,
     Builder,
-    yaml,
     _check_call,
     _fix_chart_version,
     _get_git_remote_url,
@@ -13,6 +12,7 @@ from chartpress import (
     _get_image_extra_build_command_options,
     _get_latest_commit_tagged_or_modifying_paths,
     _image_needs_pushing,
+    yaml,
 )
 
 

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -1,8 +1,7 @@
 import os
 
 import chartpress
-from chartpress import PRERELEASE_PREFIX
-from chartpress import yaml
+from chartpress import PRERELEASE_PREFIX, yaml
 
 
 def check_version(tag):


### PR DESCRIPTION
Instead of `1.2.3-n003.habc` produce `1.2.3-0.dev.git.3.habc`

## Problem

Our current dev versions don't sort correctly for various reasons:

- `n999` and `n1000` sort alphabetically, resulting in incorrect ordering
- prereleases are relative to the _most recent_ tag, which results in incorrect ordering after every release (`1.2.3` > `1.2.3-n003.habc`, when it should be the other way around) unless repos publish a prerelease tag immediately after every stable release

The only way to get prereleases to sort correctly is to produce them relative to the _next_ release, not the _previous_ release, which we get from `git describe`.

Plus, the version information is misleading - there's no indication of whether a dev version is preparing for a minor release or a major one - only that it's _after_ some version in the past.

## Proposal

- Use numerical field instead of `n012` zero-padded text fields for commit count. New tag scheme appends `.git.{n}.h{sha}` to prereleases (e.g. `1.2.3-alpha.1` -> `1.2.3-alpha.1.git.5.habc`), so commit counts are compared numerically instead of alphabetically.
- Uses leading `0.dev.` for base prerelease versions, if building a dev version from a non-prerelease version (e.g. `1.2.3` -> `1.2.3-0.dev.git.5.habc`) so that it sorts before `alpha`
- new config (opt-in) `useChartVersion` to use the version in Chart.yaml as the base version, instead of the most recent git tag.
- When using the new mode, `chartpress --reset` resets the version by stripping the `.git.{n}.h{sha}` suffix, leaving the base version alone, rather than clobbering with invalid `set-by-chartpress` tag.

Notably, this does _not_ solve the prerelease < stable release ordering by default, it only _allows_ repos to solve it by opting in to the `useChartVersion` config, and specifying the dev version in Chart.yaml, as is standard practice in software packages (1. tag a release, 2. set version to `$next-dev`). I think this is the right approach, becuse the next version is not guessable, so it has to come from the maintaners somehow, either:

1. in Chart.yaml (this implementation)
2. chartpress.yaml (also works, but Chart.yaml seems simpler to me)
3. in a git tag (forces unnatural release process)

**EDIT: original description**

When we added the `n00` prefix, I misunderstood semver restrictions about leading 0s. We can have leading 0s on fields that aren't _just_ digits (e.g. `0git` is okay, but `05` is not), so the prefix was only strictly necessary on the hash, not the count. And we can have fields that are exactly one 0 (`.0.` is okay, `.00` is not). So I think the `n00` prefix was not the best solution - `n.5` is better than `n005`. It's correctly sortable (`n.1000` > `n.999`, unlike `n1000` and `n999`), and separates the numerical field from the 'channel' field.

Further, once we have two fields, I think we should sort before 'alpha', so that a pre-alpha dev release (1.2.3-$tag) will sort before the following alpha (1.2.3-alpha.$tag). I chose `0git` for this, but I'm not sure that's best. Coud use `0.dev.git`

To this end, I propose changing our tag scheme from `n{n:03}.h{hash}` to `0git.{n}.h{hash}`:

- allows fully numerical fields to sort properly
- still avoids leading 0s on numerical fields
- prefix with `0git.` to sort before 'alpha.'

Other options:

1. No `0git.` prefix, just use numbers. This _might_ be confusing for a version that already has a number, like `1.0.0-alpha.1.5.habc` or `--long` tags with no commits like `1.0.0-0.habc`.
4. use just `0`: `1.0.0-alpha.1.0.5.habc`
5. use just `git` or `n` - I like these better aesthetically, but they have the problem that they sort after `alpha` and `beta`, so `1.2.3-git.5.habc > 1.2.3-alpha.1`


closes #174