### PR TITLE
accept --tag arg in --reset

### DIFF
--- a/chartpress.py
+++ b/chartpress.py
@@ -1003,7 +1003,7 @@ def main(args=None):
         forced_version = None
         if args.tag:
             forced_version = args.tag
-        if args.reset:
+        elif args.reset:
             forced_version = chart.get("resetVersion", "0.0.1-set.by.chartpress")
 
         if not args.list_images:

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -55,6 +55,10 @@ def test_chartpress_run(git_repo, capfd):
         in out
     )
 
+    # --tag overrides resetVersion config
+    out = _capture_output(["--reset", "--tag=1.0.0-dev"], capfd)
+    assert "Updating testchart/Chart.yaml: version: 1.0.0-dev" in out
+
     # verify that we don't need to rebuild the image
     out = _capture_output([], capfd)
     assert f"Skipping build" in out


### PR DESCRIPTION
allows `chartpress --reset --tag 2.0.0-dev`. Related to #150