### PR TITLE
pre-commit: add pyupgrade and isort (replaces reorder-python-imports)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,14 @@
 # - Register git hooks: pre-commit install --install-hooks
 #
 repos:
+  # Autoformat: Python code, syntax patterns are modernized
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.37.3
+    hooks:
+      - id: pyupgrade
+        args:
+          - --py37-plus
+
   # Autoformat: Python code
   - repo: https://github.com/psf/black
     rev: 22.6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,19 +22,25 @@ repos:
     rev: 22.6.0
     hooks:
       - id: black
-        args: [--target-version=py36]
+        args:
+          - --target-version=py37
+          - --target-version=py38
+          - --target-version=py39
+          - --target-version=py310
+
+  # Autoformat: Python code
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        args:
+          - --profile=black
 
   # Autoformat: markdown, yaml
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1
     hooks:
       - id: prettier
-
-  # Autoformat: https://github.com/asottile/reorder_python_imports
-  - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.8.2
-    hooks:
-      - id: reorder-python-imports
 
   # Misc...
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/chartpress.py
+++ b/chartpress.py
@@ -13,8 +13,7 @@ import subprocess
 import sys
 from collections.abc import MutableMapping
 from enum import Enum
-from functools import lru_cache
-from functools import partial
+from functools import lru_cache, partial
 from tempfile import TemporaryDirectory
 
 import docker

--- a/tests/test_chartpress.py
+++ b/tests/test_chartpress.py
@@ -1,9 +1,7 @@
 import json
 import sys
-from subprocess import PIPE
-from subprocess import run
-from urllib.request import Request
-from urllib.request import urlopen
+from subprocess import PIPE, run
+from urllib.request import Request, urlopen
 from uuid import uuid4
 
 import pytest
@@ -13,8 +11,7 @@ def test_list_images(git_repo):
     p = run(
         [sys.executable, "-m", "chartpress", "--list-images"],
         check=True,
-        stdout=PIPE,
-        stderr=PIPE,
+        capture_output=True,
     )
     stdout = p.stdout.decode("utf8").strip()
     # echo stdout/stderr for debugging
@@ -30,8 +27,7 @@ def test_list_images(git_repo):
     p = run(
         ["git", "status", "--porcelain"],
         check=True,
-        stdout=PIPE,
-        stderr=PIPE,
+        capture_output=True,
     )
     assert not p.stdout, "--list-images should not make changes!"
 
@@ -86,8 +82,7 @@ def test_buildx(git_repo):
             tag,
         ],
         check=True,
-        stdout=PIPE,
-        stderr=PIPE,
+        capture_output=True,
     )
     stdout = p.stdout.decode("utf8").strip()
     stderr = p.stderr.decode("utf8").strip()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,16 +1,18 @@
 import pytest
 from ruamel.yaml import YAML
 
-from chartpress import _check_call
-from chartpress import _get_git_remote_url
-from chartpress import _get_identifier_from_parts
-from chartpress import _get_image_build_args
-from chartpress import _get_image_extra_build_command_options
-from chartpress import _get_latest_commit_tagged_or_modifying_paths
-from chartpress import _image_needs_pushing
-from chartpress import Builder
-from chartpress import GITHUB_ACTOR_KEY
-from chartpress import GITHUB_TOKEN_KEY
+from chartpress import (
+    GITHUB_ACTOR_KEY,
+    GITHUB_TOKEN_KEY,
+    Builder,
+    _check_call,
+    _get_git_remote_url,
+    _get_identifier_from_parts,
+    _get_image_build_args,
+    _get_image_extra_build_command_options,
+    _get_latest_commit_tagged_or_modifying_paths,
+    _image_needs_pushing,
+)
 
 # use safe roundtrip yaml loader
 yaml = YAML(typ="rt")

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -117,7 +117,7 @@ def test_chartpress_run(git_repo, capfd):
     git_repo.git.checkout("gh-pages")
 
     # verify result of --publish-chart
-    with open("index.yaml", "r") as f:
+    with open("index.yaml") as f:
         index_yaml = f.read()
     print(index_yaml)
     assert f"version: 1.2.1" in index_yaml
@@ -180,7 +180,7 @@ def test_chartpress_run(git_repo, capfd):
     git_repo.git.checkout("gh-pages")
 
     # verify result of --publish-chart
-    with open("index.yaml", "r") as f:
+    with open("index.yaml") as f:
         index_yaml = f.read()
     print("index_yaml follows:")
     print(index_yaml)


### PR DESCRIPTION
Aligning this repo to have various hooks most other jupyterhub repo's have.