### PR TITLE
don't reset commit count on each tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ order that could come from using chartpress.
 0.8.0-0.dev.git.4.hasdf123
 0.8.0-0.dev.git.10.hsdfg234
 0.9.0-beta.1
-0.9.0-beta.1.git.1.hdfgh345
-0.9.0-beta.1.git.5.hfghj456
+0.9.0-beta.1.git.12.hdfgh345
+0.9.0-beta.1.git.15.hfghj456
 0.9.0-beta.2
-0.9.0-beta.2.git.1.hghjk567
+0.9.0-beta.2.git.20.hghjk567
 0.9.0-beta.3
 0.9.0
 ```

--- a/chartpress.py
+++ b/chartpress.py
@@ -511,6 +511,7 @@ def _get_identifier_from_paths(*paths, long=False, base_version=None):
         if base_version is None:
             base_version = latest_tag_in_branch
     except subprocess.CalledProcessError:
+        # no tags on branch
         pass
 
     if base_version is None:

--- a/chartpress.py
+++ b/chartpress.py
@@ -474,6 +474,17 @@ def _image_needs_building(image, platforms):
 def _get_identifier_from_paths(*paths, long=False, base_version=None):
     latest_commit = _get_latest_commit_tagged_or_modifying_paths(*paths, echo=False)
 
+    # always use monotonic counter since the beginning of the branch
+    # avoids counter resets when using explicit base_version
+    n_commits = int(
+        _check_output(
+            ["git", "rev-list", "--count", latest_commit],
+            echo=False,
+        )
+        .decode("utf-8")
+        .strip()
+    )
+
     try:
         git_describe = (
             _check_output(
@@ -484,30 +495,28 @@ def _get_identifier_from_paths(*paths, long=False, base_version=None):
             .decode("utf8")
             .strip()
         )
-        latest_tag_in_branch, n_commits, sha = git_describe.rsplit("-", maxsplit=2)
-        n_commits = int(n_commits)
+        latest_tag_in_branch, n_commits_since_tag, _g_sha = git_describe.rsplit(
+            "-", maxsplit=2
+        )
+        n_commits_since_tag = int(n_commits_since_tag)
+        if n_commits_since_tag == 0:
+            # don't use baseVersion config for development versions
+            # when we are exactly on a tag
+            base_version = latest_tag_in_branch
+            if not long:
+                # set n_commits=0 to ensure exact tag is used without suffix
+                # in _get_identifier_from_parts
+                n_commits = 0
+
         if base_version is None:
             base_version = latest_tag_in_branch
-        # remove "g" prefix output by the git describe command
-        # ref: https://git-scm.com/docs/git-describe#_examples
-        sha = sha[1:]
     except subprocess.CalledProcessError:
-        # no tags on branch, so assume 0.0.1 and
-        # calculate n_commits from latest_commit
-        n_commits = int(
-            _check_output(
-                ["git", "rev-list", "--count", latest_commit],
-                echo=False,
-            )
-            .decode("utf-8")
-            .strip()
-        )
-        sha = latest_commit
+        pass
 
     if base_version is None:
-        base_version = "0.0.1"
+        base_version = "0.0.1-0.dev"
 
-    return _get_identifier_from_parts(base_version, n_commits, sha, long)
+    return _get_identifier_from_parts(base_version, n_commits, latest_commit, long)
 
 
 def _get_identifier_from_parts(tag, n_commits, commit, long):

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -109,11 +109,17 @@ def test_chartpress_run(git_repo, capfd, use_chart_version):
     # already.
     assert "Updating" not in out
 
+    # Run again, but from a clean repo (versions in git don't match tag)
+    # Should produce the same result
+    git_repo.git.checkout(tag, "--", "testchart/values.yaml")
+    out = _capture_output(["--skip-build"], capfd)
+    assert f"Updating testchart/values.yaml: image: testchart/testimage:{tag}\n" in out
+
     # verify usage of --long
     out = _capture_output(["--skip-build", "--long"], capfd)
-    assert f"Updating testchart/Chart.yaml: version: {tag}.git.0.h{sha}" in out
+    assert f"Updating testchart/Chart.yaml: version: {tag}.git.1.h{sha}" in out
     assert (
-        f"Updating testchart/values.yaml: image: testchart/testimage:{tag}.git.0.h{sha}"
+        f"Updating testchart/values.yaml: image: testchart/testimage:{tag}.git.1.h{sha}"
         in out
     )
 
@@ -198,7 +204,7 @@ def test_chartpress_run(git_repo, capfd, use_chart_version):
     # verify output of --publish-chart
     assert "'gh-pages' set up to track" in out
     assert "Successfully packaged chart and saved it to:" in out
-    assert f"/testchart-{tag}.git.1.h{sha}.tgz" in out
+    assert f"/testchart-{tag}.git.2.h{sha}.tgz" in out
     assert "Skipping chart publishing" not in out
 
     # checkout gh-pages
@@ -214,7 +220,7 @@ def test_chartpress_run(git_repo, capfd, use_chart_version):
     assert "version: 1.2.1" in index_yaml
     assert "version: 1.2.2" in index_yaml
     assert f"version: {tag}" in index_yaml
-    assert f"version: {tag}.git.1.h{sha}" in index_yaml
+    assert f"version: {tag}.git.2.h{sha}" in index_yaml
 
     # return to main
     git_repo.git.checkout("main")
@@ -341,7 +347,7 @@ def test_dev_tag(git_repo_dev_tag, capfd):
     with open("testchart/Chart.yaml") as f:
         chart = yaml.load(f)
 
-    tag = f"2.0.0-dev.git.1.h{sha}"
+    tag = f"2.0.0-dev.git.3.h{sha}"
     assert chart["version"] == tag
     check_version(tag)
 
@@ -353,7 +359,7 @@ def test_backport_branch(git_repo_backport_branch, capfd):
     with open("testchart/Chart.yaml") as f:
         chart = yaml.load(f)
 
-    tag = f"1.0.1-{PRERELEASE_PREFIX}.1.h{sha}"
+    tag = f"1.0.1-{PRERELEASE_PREFIX}.3.h{sha}"
     assert chart["version"] == tag
     check_version(tag)
 


### PR DESCRIPTION
always count from the beginning, ensuring the count increases no matter what the base version or recent tag.

I believe this also resolves the 'implicit tag' issue in #177. We already had a [test](https://github.com/jupyterhub/chartpress/blob/main/tests/test_repo_interactions.py#L110) for this, but it didn't ensure the repo was clean, so useChartVersion passed (and it would have worked, too, since the useChartVersion workflow means committing changes to the Chart.yaml).

I'll open a separate PR trading useChartVersion for baseVersion in chartpress.yaml