### PR TITLE
use baseVersion config to set the base version for development releases

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,9 +1,11 @@
+from unittest import mock
+
 import pytest
 
+import chartpress
 from chartpress import (
     GITHUB_ACTOR_KEY,
     GITHUB_TOKEN_KEY,
-    Builder,
     _check_call,
     _fix_chart_version,
     _get_git_remote_url,
@@ -157,3 +159,38 @@ def test__get_image_extra_build_command_options(git_repo):
                     "ref=tag-sha",
                     "--rm",
                 ]
+
+
+@pytest.mark.parametrize(
+    "base_version, tag, n_commits, status",
+    [
+        # OK, normal state
+        ("1.2.4-0.dev", "1.2.3", 10, "ok"),
+        # don't compare prereleases on the same tag
+        ("1.2.3-0.dev", "1.2.3-alpha.1", 10, "ok"),
+        # invalid baseVersion (not semver)
+        ("x.y.z", "1.2.3", 10, "valid semver prerelease"),
+        # not prerelease baseVersion
+        ("1.2.4", "1.2.3", 10, "valid semver prerelease"),
+        # check comparison with tag
+        ("1.2.2-0.dev", "1.2.3-alpha.1", 10, "is not greater"),
+        ("1.2.3-0.dev", "1.2.3", 10, "is not greater"),
+        ("1.2.3-0.dev", "2.0.0", 10, "is not greater"),
+        ("1.2.3-0.dev", "1.2.4-alpha.1", 10, "is not greater"),
+        # don't check exactly on a tag
+        ("1.2.3-0.dev", "2.0.0", 0, "ok"),
+        # ignore invalid semver tags
+        ("1.2.3-0.dev", "x.y.z", 10, "ok"),
+    ],
+)
+def test_check_base_version(base_version, tag, n_commits, status):
+    with mock.patch.object(
+        chartpress, "_get_latest_tag_and_count", lambda: (tag, n_commits)
+    ):
+        if status == "ok":
+            chartpress._check_base_version(base_version)
+        else:
+            with pytest.raises(ValueError) as exc:
+                chartpress._check_base_version(base_version)
+            assert status in str(exc)
+            assert base_version in str(exc)


### PR DESCRIPTION
instead of useChartVersion. This greatly simplifies the implementation because we aren't storing state in an auto-updated field (i.e. `--reset` doesn't depend on baseVersion config anymore).

- baseVersion is only ever considered for development versions (tag unspecified)
- <del>building from a tag is guaranteed to be identical to building with `--tag` specified</del> couldn't quite do this because `--tag` conflicts with `--long` and I don't want to detangle that. I don't think that conflict should exist, but that's outside the scope here.
- When used, baseVersion is validated against the latest tag to ensure correct ordering of dev versions (including when calling `--reset` for CI purposes)
- consolidate a few repetitive git describe calls into functions