### PR TITLE
accept non-prerelease baseVersion (append -0.dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,11 +178,10 @@ charts:
     # This gives you more control over development version tags
     # and lets you ensure prerelease tags are always sorted in the right order.
     # Only useful when publishing development releases.
-    # if this is not a prerelease version (no -suffix),
+    # Recommended together with a version-bumping tool like `tbump`.
+    # if baseVersion is not a prerelease version (no -suffix),
     # the suffix `-0.dev` will be appended.
-    baseVersion: 3.2.1
-    # which is equivalent to
-    # baseVersion: 3.2.1-0.dev
+    baseVersion: 3.2.1-0.dev
 
     # The git repo whose gh-pages contains the charts. This can be a local
     # path such as "." as well but if matching <organization>/<repo> will be
@@ -293,24 +292,31 @@ This takes some extra configuration, and steps in your release process:
    ```
 
 2. You must update baseVersion, especially after making a release.
+   We recommend using a version bumping tool like [tbump][] to keep your baseVersion config and git tags in sync.
+
+[tbump]: https://github.com/your-tools/tbump
 
 A release process would generally look like this:
 
 ```bash
 V=1.2.3
-git tag -am "release $V" "$V"
-git push --atomic --follow-tags
+# tbump updates version, commits changes, tags commit, pushes branch and tag
+tbump "$V"
 
 # back to development
 NEXT_V=1.2.4-0.dev
-# edit chartpress.yaml to set baseVersion: $NEXT_V
-git add chartpress.yaml
-git commit -m "Back to $NEXT_V"
-git push --atomic
+# bump version config, but no tag for starting development
+tbump --no-tag "${NEXT_V}"
 ```
 
 Any prerelease fields (such as `-0.dev` above, or `-alpha.1`)
 will be left as-is, with the `.git.n.hash` suffix added.
+If there is no prerelease (e.g. on the exact commit of a tagged release),
+`-0.dev` will be added to the base version.
+You **must** update baseVersion after making a release,
+or `chartpress --reset` will fail due to incorrect ordering of versions.
+
+A sample tbump config file can be found in [our tests](./tests/test_helm_chart/tbump.toml).
 
 ## Caveats
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,11 @@ charts:
     # This gives you more control over development version tags
     # and lets you ensure prerelease tags are always sorted in the right order.
     # Only useful when publishing development releases.
-    baseVersion: 3.2.1-0.dev
+    # if this is not a prerelease version (no -suffix),
+    # the suffix `-0.dev` will be appended.
+    baseVersion: 3.2.1
+    # which is equivalent to
+    # baseVersion: 3.2.1-0.dev
 
     # The git repo whose gh-pages contains the charts. This can be a local
     # path such as "." as well but if matching <organization>/<repo> will be

--- a/chartpress.py
+++ b/chartpress.py
@@ -984,7 +984,7 @@ def _check_base_version(base_version):
     match = _semver2.fullmatch(base_version)
     if not match:
         raise ValueError(
-            f"baseVersion: {base_version} must be a valid semver prerelease (e.g. 1.2.3-0.dev), but doesn't appear to be valid."
+            f"baseVersion: {base_version} must be a valid semver version (e.g. 1.2.3-0.dev), but doesn't appear to be valid."
         )
     base_version_groups = match.groupdict()
 

--- a/chartpress.py
+++ b/chartpress.py
@@ -976,6 +976,10 @@ def _check_base_version(base_version):
     2. sort after the latest tag on the branch
     """
 
+    if "-" not in base_version:
+        # config version is a stable release,
+        # append default '-0.dev' so we always produce a prerelease
+        base_version = f"{base_version}-0.dev"
     # check valid value (baseVersion must be semver prerelease)
     match = _semver2.fullmatch(base_version)
     if not match:
@@ -983,10 +987,6 @@ def _check_base_version(base_version):
             f"baseVersion: {base_version} must be a valid semver prerelease (e.g. 1.2.3-0.dev), but doesn't appear to be valid."
         )
     base_version_groups = match.groupdict()
-    if not base_version_groups["prerelease"]:
-        raise ValueError(
-            f"baseVersion: {base_version} must be a valid semver prerelease (e.g. 1.2.3-0.dev), but is not a prerelease."
-        )
 
     def _version_number(groups):
         """Return comparable semver"""
@@ -1019,6 +1019,9 @@ def _check_base_version(base_version):
         else:
             # tag not semver. ignore? Not really our problem.
             _log(f"Latest tag {tag} does not appear to be a semver version")
+
+    # return base_version, in case it was modified
+    return base_version
 
 
 class ActionStoreDeprecated(argparse.Action):
@@ -1183,7 +1186,7 @@ def main(argv=None):
             # (e.g. forgetting to update after release)
             base_version = chart.get("baseVersion", None)
             if base_version:
-                _check_base_version(base_version)
+                base_version = _check_base_version(base_version)
 
         if not args.list_images:
             # update Chart.yaml with a version

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,3 +4,4 @@ gitpython
 pre-commit
 pytest
 pytest-cov
+tbump

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,20 @@ def git_repo_alternative(monkeypatch, git_repo):
     yield r
 
 
+@pytest.fixture
+def git_repo_base_version(monkeypatch, git_repo):
+    """
+    This fixture modifies the default git_repo fixture to use another the
+    chartpress_alternative.yaml as chartpress.yaml.
+    """
+    r = git_repo
+    shutil.move("chartpress_base_version.yaml", "chartpress.yaml")
+    r.git.add(all=True)
+    r.index.commit("chartpress_base_version.yaml initial commit")
+
+    yield r
+
+
 class MockCheckCall:
     def __init__(self):
         self.commands = []

--- a/tests/test_helm_chart/chartpress_base_version.yaml
+++ b/tests/test_helm_chart/chartpress_base_version.yaml
@@ -1,0 +1,15 @@
+charts:
+  - name: testchart
+    baseVersion: "1.0.0-0.dev"
+    resetTag: test-reset-tag
+    resetVersion: 0.0.1-test.reset.version
+    imagePrefix: testchart/
+    paths:
+      - extra-chart-path.txt
+    images:
+      testimage:
+        dockerfilePath: image/Dockerfile
+        valuesPath:
+          - image
+        paths:
+          - extra-image-path.txt

--- a/tests/test_helm_chart/tbump.toml
+++ b/tests/test_helm_chart/tbump.toml
@@ -1,0 +1,35 @@
+# tbump config sets baseVersion in chartpress.yaml
+[version]
+current = "1.0.0-0.dev"
+
+# match our prerelease prefixes
+# -alpha.1
+# -beta.2
+# -0.dev
+
+regex = '''
+  (?P<major>\d+)
+  \.
+  (?P<minor>\d+)
+  \.
+  (?P<patch>\d+)
+  (\-
+    (?P<prelease>
+      (
+       (alpha|beta|rc)\.\d+|
+       0\.dev
+      )
+    )
+  )?
+  '''
+
+[git]
+message_template = "Bump to {new_version}"
+tag_template = "{new_version}"
+
+# For each file to patch, add a [[file]] config
+# section containing the path of the file, relative to the
+# tbump.toml location.
+[[file]]
+src = "chartpress.yaml"
+search = 'baseVersion: "{current_version}"'

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -169,7 +169,7 @@ def test__get_image_extra_build_command_options(git_repo):
         # don't compare prereleases on the same tag
         ("1.2.3-0.dev", "1.2.3-alpha.1", 10, "1.2.3-0.dev"),
         # invalid baseVersion (not semver)
-        ("x.y.z", "1.2.3", 10, ValueError("valid semver pre")),
+        ("x.y.z", "1.2.3", 10, ValueError("valid semver version")),
         # not prerelease baseVersion
         ("1.2.4", "1.2.3", 10, "1.2.4-0.dev"),
         # check comparison with tag


### PR DESCRIPTION
allows clearer behavior, simpler config without dictating everyone add the same 0.dev suffix by default.

No practical effect, other than `baseVersion: 1.2.3` is equivalent to `baseVersion: 1.2.3-0.dev` instead of raising an error telling you to use `1.2.3-0.dev`.

Importantly, this is required for chartpress to be used with an automatic version-bumping tool like `tbump`.