### PR TITLE
Add BRANCH expansion

### DIFF
--- a/chartpress.py
+++ b/chartpress.py
@@ -275,7 +275,6 @@ def _get_current_branchname(**kwargs):
     )
 
 
-
 def _get_image_build_args(image_options, ns):
     """
     Render buildArgs from chartpress.yaml that could be templates, using
@@ -690,7 +689,7 @@ def build_images(
                     *all_image_paths, echo=False
                 ),
                 "TAG": image_tag,
-                "BRANCH": _get_current_branchname(echo=False)
+                "BRANCH": _get_current_branchname(echo=False),
             }
             build_image(
                 image_spec,

--- a/chartpress.py
+++ b/chartpress.py
@@ -256,6 +256,26 @@ def _get_latest_commit_tagged_or_modifying_paths(*paths, **kwargs):
         return latest_commit_modifying_path
 
 
+def _get_current_branchname(**kwargs):
+    """
+    Get the current branch name from Git.
+    """
+    return (
+        _check_output(
+            [
+                "git",
+                "symbolic-ref",
+                "--short",
+                "HEAD",
+            ],
+            **kwargs,
+        )
+        .decode("utf-8")
+        .strip()
+    )
+
+
+
 def _get_image_build_args(image_options, ns):
     """
     Render buildArgs from chartpress.yaml that could be templates, using
@@ -663,7 +683,6 @@ def build_images(
             if not platforms:
                 _log(f"Skipping build for {image_spec}, no matching platforms")
                 continue
-
         # build image and optionally push image
         if force_build or _image_needs_building(image_spec, platforms):
             expansion_namespace = {
@@ -671,6 +690,7 @@ def build_images(
                     *all_image_paths, echo=False
                 ),
                 "TAG": image_tag,
+                "BRANCH": _get_current_branchname(echo=False)
             }
             build_image(
                 image_spec,

--- a/chartpress.py
+++ b/chartpress.py
@@ -264,9 +264,8 @@ def _get_current_branchname(**kwargs):
         _check_output(
             [
                 "git",
-                "symbolic-ref",
-                "--short",
-                "HEAD",
+                "branch",
+                "--show-current",
             ],
             **kwargs,
         )

--- a/tests/test_helm_chart/chartpress.yaml
+++ b/tests/test_helm_chart/chartpress.yaml
@@ -12,11 +12,11 @@ charts:
       testimage:
         buildArgs:
           TEST_STATIC_BUILD_ARG: "test"
-          TEST_DYNAMIC_BUILD_ARG: "{TAG}-{LAST_COMMIT}"
+          TEST_DYNAMIC_BUILD_ARG: "{TAG}-{LAST_COMMIT}-{BRANCH}"
         extraBuildCommandOptions:
           - --label=maintainer=octocat
           - --label
-          - ref={TAG}-{LAST_COMMIT}
+          - ref={TAG}-{LAST_COMMIT}-{BRANCH}
           - --rm
         contextPath: image
         dockerfilePath: image/Dockerfile

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -127,13 +127,14 @@ def test__get_image_build_args(git_repo):
                 {
                     "LAST_COMMIT": "sha",
                     "TAG": "tag",
+                    "BRANCH": "branch",
                 },
             )
             assert name in ("testimage", "amd64only")
             if name == "testimage":
                 assert build_args == {
                     "TEST_STATIC_BUILD_ARG": "test",
-                    "TEST_DYNAMIC_BUILD_ARG": "tag-sha",
+                    "TEST_DYNAMIC_BUILD_ARG": "tag-sha-branch",
                 }
             else:
                 assert build_args == {}
@@ -149,6 +150,7 @@ def test__get_image_extra_build_command_options(git_repo):
                 {
                     "LAST_COMMIT": "sha",
                     "TAG": "tag",
+                    "BRANCH": "branch",
                 },
             )
             assert name in ("testimage", "amd64only")
@@ -156,7 +158,7 @@ def test__get_image_extra_build_command_options(git_repo):
                 assert extra_build_command_options == [
                     "--label=maintainer=octocat",
                     "--label",
-                    "ref=tag-sha",
+                    "ref=tag-sha-branch",
                     "--rm",
                 ]
 

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -45,6 +45,7 @@ def test_chartpress_run(git_repo, capfd, base_version):
     # summarize information from git_repo
     sha = git_repo.commit("HEAD").hexsha[:7]
     tag = f"0.0.1-{PRERELEASE_PREFIX}.1.h{sha}"
+    branch = "main"
     check_version(tag)
 
     # run chartpress
@@ -56,7 +57,7 @@ def test_chartpress_run(git_repo, capfd, base_version):
 
     # verify the passing of static and dynamic --build-args
     assert "--build-arg TEST_STATIC_BUILD_ARG=test" in out
-    assert f"--build-arg TEST_DYNAMIC_BUILD_ARG={tag}-{sha}" in out
+    assert f"--build-arg TEST_DYNAMIC_BUILD_ARG={tag}-{sha}-{branch}" in out
 
     # verify updates of Chart.yaml and values.yaml
     assert f"Updating testchart/Chart.yaml: version: {tag}" in out


### PR DESCRIPTION
Much like `TAG` or `LAST_COMMIT`, add an expansion for `BRANCH` to expand to the current Git branch.

This is useful if you are using OCI image caching via extraBuildArgs, like so:
```
        extraBuildCommandOptions:
          - --cache-to
          - type=registry,ref=ghcr.io/myorg/myimg-buildcache:{BRANCH}
          - --cache-from
          - type=registry,ref=ghcr.io/myorg/myimg-buildcache:{BRANCH}
```

PR branches won't have TAG for us, and LAST_COMMIT will create new caches for every new Git SHA, which defeats the purpose of a `docker buildx` cache save/restore.


NOTE - I cannot get the existing tests on `main` to pass locally with current Docker release, as the default `docker build` output format doesn't match what the tests expect - if I am missing something here let me know, otherwise I will try to debug any test failures via CI.