### PR TITLE
dependabot: monthly updates of github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,4 +1,4 @@
-# dependabot.yml reference: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+# dependabot.yaml reference: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
 #
 # Notes:
 # - Status and logs from dependabot are provided at

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,16 +5,13 @@
 #   https://github.com/jupyterhub/chartpress/network/updates.
 # - YAML anchors are not supported here or in GitHub Workflows.
 #
-
 version: 2
 updates:
   # Maintain dependencies in our GitHub Workflows
-  - package-ecosystem: "github-actions"
-    directory: "/" # This should be / rather than .github/workflows
+  - package-ecosystem: github-actions
+    directory: /
+    labels: [ci]
     schedule:
-      interval: daily
+      interval: monthly
       time: "05:00"
-      timezone: "Etc/UTC"
-    labels:
-      - maintenance
-      - dependencies
+      timezone: Etc/UTC


### PR DESCRIPTION
This is one of several PRs opened in the juptyterhub github organization to systematically configure dependabot to update github actions on a monthly basis, for more information see https://github.com/jupyterhub/team-compass/issues/636.