### PR TITLE
maint: let tests check the output against another set of strings

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,5 +1,5 @@
 # This is a GitHub workflow defining a set of jobs with a set of steps.
-# ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+# ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
 #
 # Publish to PyPI on push of version like tags
 #
@@ -24,12 +24,12 @@ on:
 
 jobs:
   publish-to-pypi:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: install build package
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,5 @@
 # This is a GitHub workflow defining a set of jobs with a set of steps.
-# ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+# ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
 #
 name: Test
 
@@ -21,7 +21,7 @@ on:
 
 jobs:
   chart-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       # Keep running even if one variation of the job fail
@@ -36,6 +36,7 @@ jobs:
           - python: "3.8"
           - python: "3.9"
           - python: "3.10"
+          - python: "3.11"
 
     services:
       local-registry:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,5 +102,5 @@ jobs:
         run: |
           pytest --verbose --color=yes --cov chartpress
 
-      - name: Upload coverage report
-        run: codecov
+      # GitHub action reference: https://github.com/codecov/codecov-action
+      - uses: codecov/codecov-action@v3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 bump2version
-codecov
 gitpython
 pre-commit
 pytest

--- a/tests/test_chartpress.py
+++ b/tests/test_chartpress.py
@@ -117,15 +117,15 @@ def test_buildx(git_repo, capfd):
     # Note: Parsing stderr for these logs may be fragile. We could probably omit
     # it and just verify the registry manifests instead.
 
-    assert "[linux/amd64 1/1] FROM docker.io/library/alpine@" in stderr
-    assert "[linux/arm64 1/1] FROM docker.io/library/alpine@" in stderr
-    assert "[linux/ppc64le 1/1] FROM docker.io/library/alpine@" in stderr
+    assert "[linux/amd64 1/1] FROM docker.io/library/alpine" in stderr
+    assert "[linux/arm64 1/1] FROM docker.io/library/alpine" in stderr
+    assert "[linux/ppc64le 1/1] FROM docker.io/library/alpine" in stderr
 
     # If there's only one platform it doesn't appear in the output logs
-    # assert "[linux/amd64 1/1] FROM docker.io/library/busybox@" in stderr
-    assert "[1/1] FROM docker.io/library/busybox@" in stderr
-    assert "[linux/arm64 1/1] FROM docker.io/library/busybox@" not in stderr
-    assert "[linux/ppc64le 1/1] FROM docker.io/library/busybox@" not in stderr
+    # assert "[linux/amd64 1/1] FROM docker.io/library/busybox" in stderr
+    assert "[1/1] FROM docker.io/library/busybox" in stderr
+    assert "[linux/arm64 1/1] FROM docker.io/library/busybox" not in stderr
+    assert "[linux/ppc64le 1/1] FROM docker.io/library/busybox" not in stderr
 
     assert f"pushing manifest for localhost:5000/test-buildx/testimage:{tag}" in stderr
     assert f"pushing manifest for localhost:5000/test-buildx/amd64only:{tag}" in stderr

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -53,7 +53,10 @@ def test_chartpress_run(git_repo, capfd, base_version):
     print(out)
     # verify image was built
     # verify the fallback tag of "0.0.1" when a tag is missing
-    assert f"Successfully tagged testchart/testimage:{tag}" in out
+    assert (
+        f"Successfully tagged testchart/testimage:{tag}" in out
+        or f"naming to docker.io/testchart/testimage:{tag} in out"
+    )
 
     # verify the passing of static and dynamic --build-args
     assert "--build-arg TEST_STATIC_BUILD_ARG=test" in out
@@ -83,12 +86,12 @@ def test_chartpress_run(git_repo, capfd, base_version):
 
     # verify usage of --force-build
     out = _capture_output(["--force-build"], capfd)
-    assert "Successfully tagged" in out
+    assert "Successfully tagged" in out or "naming to" in out
 
     # verify usage --skip-build and --tag
     tag = "1.2.3-test.tag"
     out = _capture_output(["--skip-build", "--tag", tag], capfd)
-    assert "Successfully tagged" not in out
+    assert "Successfully tagged" not in out or "naming to" in out
     assert f"Updating testchart/Chart.yaml: version: {tag}" in out
     assert f"Updating testchart/values.yaml: image: testchart/testimage:{tag}" in out
 


### PR DESCRIPTION
Closes #191 using the simple approach of letting tests check for either outputs that is now possible to show up depending on the docker builder.