### PR TITLE
`chartPath`: Chart directory can be different from the chart name

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -101,6 +101,8 @@ jobs:
       - name: Run tests
         run: |
           pytest --verbose --color=yes --cov chartpress
+        env:
+          HELM2: ${{ matrix.helm2 }}
 
       # GitHub action reference: https://github.com/codecov/codecov-action
       - uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -161,8 +161,12 @@ for each chart. Below is an example `chartpress.yaml` file.
 ```yaml
 charts:
   # list of charts by name
-  # each name should be a directory containing a helm chart
+  # each name should be the name of a Helm chart
   - name: binderhub
+    # Directory containing the chart, relative to chartpress.yaml.
+    # Can be omitted if the directory is the same as the chart name.
+    chartPath: helm-charts/binderhub
+
     # the prefix to use for built images
     imagePrefix: jupyterhub/k8s-
     # tag to use when resetting the chart values

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,7 +135,7 @@ def git_repo_backport_branch(git_repo_dev_tag):
 @pytest.fixture
 def git_repo_alternative(monkeypatch, git_repo):
     """
-    This fixture modifies the default git_repo fixture to use another the
+    This fixture modifies the default git_repo fixture to use
     chartpress_alternative.yaml as chartpress.yaml.
     """
     r = git_repo
@@ -149,8 +149,8 @@ def git_repo_alternative(monkeypatch, git_repo):
 @pytest.fixture
 def git_repo_base_version(monkeypatch, git_repo):
     """
-    This fixture modifies the default git_repo fixture to use another the
-    chartpress_alternative.yaml as chartpress.yaml.
+    This fixture modifies the default git_repo fixture to use
+    chartpress_base_version.yaml as chartpress.yaml.
     """
     r = git_repo
     shutil.move("chartpress_base_version.yaml", "chartpress.yaml")

--- a/tests/test_helm_chart/chartpress_alternative.yaml
+++ b/tests/test_helm_chart/chartpress_alternative.yaml
@@ -1,7 +1,8 @@
 charts:
-  - name: testchart
+  - name: alternative
+    chartPath: subdir/chart
     images:
       testimage:
-        imageName: testimage
+        imageName: alternativeimage
         contextPath: image
         valuesPath: image

--- a/tests/test_helm_chart/chartpress_alternative.yaml
+++ b/tests/test_helm_chart/chartpress_alternative.yaml
@@ -6,3 +6,6 @@ charts:
         imageName: alternativeimage
         contextPath: image
         valuesPath: image
+    repo:
+      git: "."
+      published: https://test.local

--- a/tests/test_helm_chart/subdir/chart/Chart.yaml
+++ b/tests/test_helm_chart/subdir/chart/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+name: alternative
+version: 0.0.1-set.by.chartpress

--- a/tests/test_helm_chart/subdir/chart/templates/configmap.yaml
+++ b/tests/test_helm_chart/subdir/chart/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+data:
+  test.json: |
+    {
+      "alternativeKey": "alternativeValue"
+    }

--- a/tests/test_helm_chart/subdir/chart/values.yaml
+++ b/tests/test_helm_chart/subdir/chart/values.yaml
@@ -1,0 +1,4 @@
+image: alternative/alternative:set-by-chartpress
+list:
+  - "alternative/alternative:set-by-chartpress"
+  - image: "alternative/alternative:set-by-chartpress"

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -452,6 +452,7 @@ def test_chartpress_run_bare_minimum(git_repo_bare_minimum, capfd):
     assert f"Updating testchart/Chart.yaml: version: {tag}" in out
 
 
+@pytest.mark.skipif(os.environ.get("HELM2") == "helm2", reason="Skipping helm 2")
 def test_chartpress_run_alternative(git_repo_alternative, capfd):
     """
     Ensures that chartpress will run with an alternative configuration. This
@@ -466,9 +467,13 @@ def test_chartpress_run_alternative(git_repo_alternative, capfd):
     tag = "v1.0.0"
     check_version(tag)
 
-    out = _capture_output(["--skip-build", "--tag", tag], capfd)
+    out = _capture_output(["--skip-build", "--tag", tag, "--publish-chart"], capfd)
     assert f"Updating subdir/chart/Chart.yaml: version: {tag[1:]}" in out
     assert f"Updating subdir/chart/values.yaml: image: alternativeimage:{tag}" in out
+
+    gh_pages = r.heads["gh-pages"].commit.tree
+    expected_files = sorted(b.name for b in gh_pages.blobs)
+    assert expected_files == ["alternative-1.0.0.tgz", "index.yaml"]
 
 
 def _capture_output(args, capfd, expect_output=False):

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -456,7 +456,8 @@ def test_chartpress_run_alternative(git_repo_alternative, capfd):
     """
     Ensures that chartpress will run with an alternative configuration. This
     allow us to test against more kinds of configurations than we could squeeze
-    into a single chartpress.yaml file.
+    into a single chartpress.yaml file, including:
+    - chart name != chart directory name
     """
     r = git_repo_alternative
     sha = r.heads.main.commit.hexsha[:7]
@@ -466,8 +467,8 @@ def test_chartpress_run_alternative(git_repo_alternative, capfd):
     check_version(tag)
 
     out = _capture_output(["--skip-build", "--tag", tag], capfd)
-    assert f"Updating testchart/Chart.yaml: version: {tag[1:]}" in out
-    assert f"Updating testchart/values.yaml: image: testimage:{tag}" in out
+    assert f"Updating subdir/chart/Chart.yaml: version: {tag[1:]}" in out
+    assert f"Updating subdir/chart/values.yaml: image: alternativeimage:{tag}" in out
 
 
 def _capture_output(args, capfd, expect_output=False):


### PR DESCRIPTION
This makes it easier to organise charts in a git repo, for example the chart could be under `PROJECT-NAME/helm-chart` instead of `PROJECT-NAME/helm-chart/PROJECT-NAME`, whilst still keeping chartpress.yaml at the root of the repository.

This is a Helm 3 feature https://github.com/helm/helm/issues/1979 (should we drop Helm 2 instead of having a conditional test?)