### PR TITLE
Remove `pipes` for compatibility with Python 3.13

### DIFF
--- a/chartpress.py
+++ b/chartpress.py
@@ -7,7 +7,6 @@ This is used as part of the JupyterHub and Binder projects.
 
 import argparse
 import os
-import pipes
 import re
 import shlex
 import shutil
@@ -68,7 +67,7 @@ def _log(message):
 def _run_cmd(call, cmd, *, echo=True, **kwargs):
     """Run a command and echo it first with censoring of GITHUB_TOKEN."""
     if echo:
-        cmd_string = " ".join(map(pipes.quote, cmd))
+        cmd_string = " ".join(map(shlex.quote, cmd))
         github_token = os.getenv(GITHUB_TOKEN_KEY)
         if github_token:
             cmd_string = cmd_string.replace(github_token, "CENSORED_GITHUB_TOKEN")

--- a/tests/test_repo_interactions.py
+++ b/tests/test_repo_interactions.py
@@ -1,8 +1,6 @@
-import contextlib
 import os
 import subprocess
 import sys
-import tempfile
 
 import pytest
 from conftest import cache_clear


### PR DESCRIPTION
The only thing holding `chartpress` back from [compatibility with Python 3.13 was the use of `pipes`](https://peps.python.org/pep-0594/) to quote a shell expression. Ironically the `chartpress.py` was using both `shlex.quote()` and `pipes.quote()` simultaneously. This PR removes the `pipes` import and changes the call to use `shlex`

(I also saw two unused dependencies that didn't get cleaned up in tests, so I removed those.)