### PR TITLE
ci: test against python 3.12 and 3.13

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,8 @@ jobs:
           - python: "3.9"
           - python: "3.10"
           - python: "3.11"
+          - python: "3.12"
+          - python: "3.13"
 
     services:
       local-registry:


### PR DESCRIPTION
I understand that chartpress is supposed to work with Python 3.13, but only in main branch and not the latest release. This is meant to verify this.